### PR TITLE
Delete community

### DIFF
--- a/bot/modules/community/commands.js
+++ b/bot/modules/community/commands.js
@@ -186,3 +186,25 @@ exports.updateCommunity = async (ctx, id, field, bot) => {
     logger.error(error);
   }
 };
+
+exports.deleteCommunity = async ctx => {
+  try {
+    ctx.deleteMessage();
+    const id = ctx.match[1];
+
+    if (!(await validateObjectId(ctx, id))) return;
+    const community = await Community.findOne({
+      _id: id,
+      creator_id: ctx.user._id,
+    });
+
+    if (!community) {
+      return ctx.reply(ctx.i18n.t('no_permission'));
+    }
+    await community.remove();
+
+    return ctx.reply(ctx.i18n.t('operation_successful'));
+  } catch (error) {
+    logger.error(error);
+  }
+};

--- a/bot/modules/community/index.js
+++ b/bot/modules/community/index.js
@@ -2,7 +2,11 @@
 const { userMiddleware } = require('../../middleware/user');
 const actions = require('./actions');
 const commands = require('./commands');
-const { earningsMessage, updateCommunityMessage } = require('./messages');
+const {
+  earningsMessage,
+  updateCommunityMessage,
+  sureMessage,
+} = require('./messages');
 exports.Scenes = require('./scenes');
 
 exports.configure = bot => {
@@ -59,10 +63,23 @@ exports.configure = bot => {
     userMiddleware,
     actions.onSetCommunity
   );
+  bot.action('doNothingBtn', userMiddleware, async ctx => {
+    await ctx.deleteMessage();
+  });
   bot.action(/^earningsBtn_([0-9a-f]{24})$/, userMiddleware, earningsMessage);
+  bot.action(
+    /^deleteCommunityAskBtn_([0-9a-f]{24})$/,
+    userMiddleware,
+    sureMessage
+  );
   bot.action(
     /^withdrawEarnings_([0-9a-f]{24})$/,
     userMiddleware,
     actions.withdrawEarnings
+  );
+  bot.action(
+    /^deleteCommunityBtn_([0-9a-f]{24})$/,
+    userMiddleware,
+    commands.deleteCommunity
   );
 };

--- a/bot/modules/community/messages.js
+++ b/bot/modules/community/messages.js
@@ -36,6 +36,7 @@ exports.createCommunityWizardStatus = (i18n, state) => {
 
 exports.updateCommunityMessage = async ctx => {
   try {
+    await ctx.deleteMessage();
     const id = ctx.match[1];
     const community = await Community.findById(id);
     let text = ctx.i18n.t('community') + `: ${community.name}\n`;
@@ -81,6 +82,12 @@ exports.updateCommunityMessage = async ctx => {
             {
               text: '💰 ' + ctx.i18n.t('earnings'),
               callback_data: `earningsBtn_${id}`,
+            },
+          ],
+          [
+            {
+              text: '☠️ ' + ctx.i18n.t('delete_community'),
+              callback_data: `deleteCommunityAskBtn_${id}`,
             },
           ],
         ],
@@ -188,6 +195,31 @@ exports.wizardCommunityWrongPermission = async (ctx, user, channel) => {
         channel,
       })
     );
+  } catch (error) {
+    logger.error(error);
+  }
+};
+
+exports.sureMessage = async ctx => {
+  try {
+    await ctx.deleteMessage();
+    const id = ctx.match[1];
+    await ctx.reply(ctx.i18n.t('are_you_sure'), {
+      reply_markup: {
+        inline_keyboard: [
+          [
+            {
+              text: '🔴 ' + ctx.i18n.t('no'),
+              callback_data: `doNothingBtn`,
+            },
+            {
+              text: '🟢 ' + ctx.i18n.t('yes'),
+              callback_data: `deleteCommunityBtn_${id}`,
+            },
+          ],
+        ],
+      },
+    });
   } catch (error) {
     logger.error(error);
   }

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -452,3 +452,6 @@ current_earnings: |
 you_dont_have_communities: Sie haben keine Community erstellt
 users_added: 'Du hast ${users} hinzugefügt.'
 users_not_added: 'Konnte ${users} nicht hinzufügen. Bitte stellen Sie sicher, dass dieser Benutzer den Bot gestartet hat (/start)'
+delete_community: Delete community
+are_you_sure: Are you sure?
+no_permission: You do not have permissions to perform this operation

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -450,3 +450,6 @@ current_earnings: |
 you_dont_have_communities: You have no communities created
 users_added: 'You have added: ${users}'
 users_not_added: 'Could not add to: ${users}; please make sure these users have started the bot'
+delete_community: Delete community
+are_you_sure: Are you sure?
+no_permission: You do not have permissions to perform this operation

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -21,7 +21,7 @@ start: |
 
   9. Si estas tomando una compra, debes pagar la factura lightning, este pago estará retenido mientras el comprador realiza tu pago fiat. Debes contactarle y brindarle tus datos para ello. Una vez confirmes su pago, debes liberar los fondos por medio del comando /release para que le lleguen los sats al comprador.
 
-  10. Si en algun punto los usuarios no pueden solucionar operación, pueden usar este comando para llamar a los admin a que resuelvan la operacion como intermediarios.
+  10. Si en algun punto los usuarios no pueden solucionar operación, pueden usar este comando para llamar a los admin a que resuelvan la operación como intermediarios.
 
   11. Antes de que cualquier otro usuario tome tu oferta de compra o venta, puedes cancelarla con el el comando /cancel.
 
@@ -450,3 +450,6 @@ must_enter_text: Debe ingresar solo texto
 you_dont_have_communities: No tienes comunidades creadas
 users_added: 'Has agregado a: ${users}'
 users_not_added: 'No he podido agregar a: ${users}; asegúrate de que estos usuarios han iniciado al bot'
+delete_community: Eliminar comunidad
+are_you_sure: ¿Estás seguro?
+no_permission: No tienes permisos para realizar esta operación

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -449,3 +449,6 @@ current_earnings: |
 you_dont_have_communities: You have no communities created
 users_added: 'You have added: ${users}'
 users_not_added: 'Could not add to: ${users}; please make sure these users have started the bot'
+delete_community: Delete community
+are_you_sure: Are you sure?
+no_permission: You do not have permissions to perform this operation

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -450,3 +450,6 @@ current_earnings: |
 you_dont_have_communities: Você não tem comunidades criadas
 users_added: 'Você foi adicionado: ${users}'
 users_not_added: 'Não poderia adicionar a: ${users}; Certifique-se de que esses usuários começaram o bot'
+delete_community: Delete community
+are_you_sure: Are you sure?
+no_permission: You do not have permissions to perform this operation

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -451,3 +451,6 @@ current_earnings: |
 you_dont_have_communities: You have no communities created
 users_added: 'You have added: ${users}'
 users_not_added: 'Could not add to: ${users}; please make sure these users have started the bot'
+delete_community: Delete community
+are_you_sure: Are you sure?
+no_permission: You do not have permissions to perform this operation

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -450,3 +450,5 @@ current_earnings: |
 you_dont_have_communities: You have no communities created
 users_added: 'You have added: ${users}'
 users_not_added: 'Could not add to: ${users}; please make sure these users have started the bot'
+are_you_sure: Are you sure?
+no_permission: You do not have permissions to perform this operation


### PR DESCRIPTION
Fix #338 

This PR add a new button to `/mycomms` command, for delete community, only owners can delete communities