### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,5 +10,52 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
+      - name: Update apt and install required packages
+        run: |
+          sudo apt update
+          sudo apt install --yes --no-install-recommends curl
+          sudo apt-get install --yes gnupg
+
+      - name: Import the public key used by the package management system
+        run: |
+          sudo rm -f /etc/ssl/certs/ca-bundle.crt
+          sudo apt reinstall --yes ca-certificates
+          sudo update-ca-certificates
+          curl -fsSL https://pgp.mongodb.com/server-6.0.asc | \
+            sudo gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg \
+            --dearmor
+
+      - name: Install MongoDB
+        run: |
+          echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+          sudo apt-get update
+          sudo apt-get install -y mongodb-org
+      - name: Check Mongo version
+        run: mongod --version
+      - name: Start MongoDB
+        run: sudo service mongod start
+      - name: Verify that MongoDB has started successfully
+        run: sudo service mongod status
+
+      - name: Create database
+        run: |
+          # this sleep is added to avoid race condition without this we sometimes get the following error:
+          # connecting to: mongodb://127.0.0.1:27017
+          # 2023-05-30T13:02:52.975+0000 W NETWORK  [thread1] Failed to connect to 127.0.0.1:27017, in(checking socket for error after poll), reason: Connection refused
+          # 2023-05-30T13:02:52.976+0000 E QUERY    [thread1] Error: couldn't connect to server 127.0.0.1:27017, connection attempt failed :
+          # connect@src/mongo/shell/mongo.js:257:13
+          # @(connect):1:6
+          # exception: connect failed
+          sleep 10
+          
+          mongosh --eval 'db.getSiblingDB("lnp2pbot").createCollection("mycollection")'
+
       - run: npm ci
-      - run: npm test
+      - name: Run tests
+        env:
+          DB_USER: ''
+          DB_PASS: ''
+          DB_HOST: 'localhost'
+          DB_PORT: '27017'
+          DB_NAME: 'lnp2pbot'
+        run: npm test

--- a/tests/bot_test.js
+++ b/tests/bot_test.js
@@ -104,7 +104,7 @@ describe('Telegram bot test', () => {
     // expect(updates.result[0].message.text).to.be.equal("/buy \\<_monto en sats_\\> \\<_monto en fiat_\\> \\<_código fiat_\\> \\<_método de pago_\\> \\[_prima/descuento_\\]");
   });
 
-  it.skip('should return the list of supported currencies', async () => {
+  it('should return the list of supported currencies', async () => {
     const client = server.getClient(token, { timeout: 5000 });
     const userStub = sinon.stub(User, 'findOne');
     userStub.returns(testUser);
@@ -119,7 +119,7 @@ describe('Telegram bot test', () => {
     ).to.be.equal(getCurrenciesWithPrice().length);
   });
 
-  it.skip('should return flags of langs supported', async () => {
+  it('should return flags of langs supported', async () => {
     const client = server.getClient(token, { timeout: 5000 });
     const userStub = sinon.stub(User, 'findOne');
     userStub.returns(testUser);

--- a/tests/bot_test.js
+++ b/tests/bot_test.js
@@ -10,6 +10,9 @@ const ordersActions = require('../bot/ordersActions');
 const testUser = require('./user');
 const testOrder = require('./order');
 const { getCurrenciesWithPrice } = require('../util');
+const mongoConnect = require('../db_connect');
+
+mongoConnect();
 
 describe('Telegram bot test', () => {
   const serverConfig = { port: 9001 };


### PR DESCRIPTION
The commit [1] caused the failure of tests because line 191 of
the start.js file in that commit:
`
const config = await Config.findOne({ maintenance: true });
`
is hanging and doesn't respond, causing a timeout and failure
of the tests. Based on [2] the reason is that we need to call
mongoose.connect(...) to connect to the database before that
line. That's why I called `connect` function from
`db_connect.js` file in the `start.js` file. There are other
similar lines in the `start.js` file like:
`
const order = await Order.findOne({ _id: orderId });
`
That doesn't cause timeout and failure of the CI and I don't
know the reason.

Fixes https://github.com/lnp2pBot/bot/issues/378

[1] https://github.com/lnp2pBot/bot/commit/ed409030deb594f689413550ce769205b36669ab
[2] https://stackoverflow.com/questions/65408618/mongooseerror-operation-users-findone-buffering-timed-out-after-10000ms