### PR TITLE
Introduces simpler LND connection method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .env
+admin.macaroon
+tls.cert

--- a/README.md
+++ b/README.md
@@ -72,15 +72,28 @@ You will need a telegram bot api key (`BOT_TOKEN`), find out more about it [here
 You can route the bot API via Tor service or another proxy if you specify 'SOCKS_PROXY_HOST' parameter in .env. For Ubuntu see [this](https://www.linuxuprising.com/2018/10/how-to-install-and-use-tor-as-proxy-in.html)
 
 ## Lightning Network
+
 You will need a lightning network node, for this bot we use [LND](https://github.com/lightningnetwork/lnd/).
 
-To connect with a lnd node we need to set 3 variables in the `.env` file,
+There are two methods to connect with an LND node:
 
-*LND_CERT_BASE64:* LND node TLS certificate on base64 format, you can get it with `base64 -w0 ~/.lnd/tls.cert` on the lnd node.
+### Method 1: Setting Variables in the `.env` File
 
-*LND_MACAROON_BASE64:* Macaroon file on base64 format, the macaroon file contains permission for doing actions on the lnd node, you can get it with `base64 -w0 ~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon`.
+To connect with an LND node we need to set 3 variables in the `.env` file,
 
-*LND_GRPC_HOST:* IP address or domain name from the LND node and the port separated by colon (`:`), example: `192.168.0.2:10009`.
+1. *LND_CERT_BASE64:* LND node TLS certificate on base64 format, you can get it with `base64 -w0 ~/.lnd/tls.cert` on the LND node.
+
+2. *LND_MACAROON_BASE64:* Macaroon file on base64 format, the macaroon file contains permission for doing actions on the LND node, you can get it with `base64 -w0 ~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon`.
+
+3. *LND_GRPC_HOST:* IP address or domain name from the LND node and the port separated by colon (`:`), example: `192.168.0.2:10009`.
+
+### Method 2: Copying Files to the Project Root
+
+Instead of setting the `LND_MACAROON_BASE64` and `LND_CERT_BASE64` variables in the `.env` file, you can simply copy the `admin.macaroon` and `tls.cert` files to the root of the project.
+
+Please note that you will still need to define the `LND_GRPC_HOST` in the `.env` file as in Method 1, step 3.
+
+Please choose one of these two methods for your setup.
 
 To install just run:
 ```

--- a/db_connect.js
+++ b/db_connect.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const logger = require('./logger');
 
 // connect to database
 const credentials = process.env.DB_USER
@@ -10,7 +11,7 @@ MONGO_URI = process.env.MONGO_URI ? process.env.MONGO_URI : MONGO_URI;
 if (!MONGO_URI) {
   throw new Error('You must provide a MongoDB URI');
 }
-
+logger.info(`Connecting to: ${MONGO_URI}`);
 const connect = () => {
   mongoose.connect(MONGO_URI, {
     useNewUrlParser: true,

--- a/ln/connect.js
+++ b/ln/connect.js
@@ -27,16 +27,16 @@ if (!macaroon && process.env.NODE_ENV !== 'test') {
 }
 
 // Enforcing presence of LND_GRPC_HOST environment variable
-const lndHost = process.env.LND_GRPC_HOST;
-if (!lndHost && process.env.NODE_ENV !== 'test') {
+const socket = process.env.LND_GRPC_HOST;
+if (!socket && process.env.NODE_ENV !== 'test') {
   throw new Error('You must provide a LND_GRPC_HOST environment variable');
 }
 
 // Use these credentials to connect to the LND node
 const { lnd } = authenticatedLndGrpc({
-    cert: cert,
-    macaroon: macaroon,
-    socket: lndHost
+    cert,
+    macaroon,
+    socket
 })
 
 module.exports = lnd;

--- a/ln/connect.js
+++ b/ln/connect.js
@@ -17,18 +17,18 @@ if (macaroon) {
 }
 
 // If environment variables are not set, try to load them from files
-if (!cert) {
+if (!cert && process.env.NODE_ENV !== 'test') {
   logger.info('Loading TLS cert from file')
   cert = fs.readFileSync(path.resolve(__dirname, '../tls.cert')).toString('base64');
 }
-if (!macaroon) {
+if (!macaroon && process.env.NODE_ENV !== 'test') {
   logger.info('Loading macaroon from file')
   macaroon = fs.readFileSync(path.resolve(__dirname, '../admin.macaroon')).toString('base64');
 }
 
 // Enforcing presence of LND_GRPC_HOST environment variable
 const lndHost = process.env.LND_GRPC_HOST;
-if (!lndHost) {
+if (!lndHost && process.env.NODE_ENV !== 'test') {
   throw new Error('You must provide a LND_GRPC_HOST environment variable');
 }
 

--- a/ln/connect.js
+++ b/ln/connect.js
@@ -1,9 +1,42 @@
+const fs = require('fs');
+const path = require('path');
 const lightning = require('lightning');
+const logger = require('../logger');
 
-const { lnd } = lightning.authenticatedLndGrpc({
-  cert: process.env.LND_CERT_BASE64,
-  macaroon: process.env.LND_MACAROON_BASE64,
-  socket: process.env.LND_GRPC_HOST,
-});
+const { authenticatedLndGrpc } = lightning;
+
+// Trying to load TLS certificate and admin macaroon from environment variables first
+let cert = process.env.LND_CERT_BASE64;
+let macaroon = process.env.LND_MACAROON_BASE64;
+
+if (cert) {
+  logger.info('Using TLS cert from environment variable')
+}
+if (macaroon) {
+  logger.info('Using macaroon from environment variable')
+}
+
+// If environment variables are not set, try to load them from files
+if (!cert) {
+  logger.info('Loading TLS cert from file')
+  cert = fs.readFileSync(path.resolve(__dirname, '../tls.cert')).toString('base64');
+}
+if (!macaroon) {
+  logger.info('Loading macaroon from file')
+  macaroon = fs.readFileSync(path.resolve(__dirname, '../admin.macaroon')).toString('base64');
+}
+
+// Enforcing presence of LND_GRPC_HOST environment variable
+const lndHost = process.env.LND_GRPC_HOST;
+if (!lndHost) {
+  throw new Error('You must provide a LND_GRPC_HOST environment variable');
+}
+
+// Use these credentials to connect to the LND node
+const { lnd } = authenticatedLndGrpc({
+    cert: cert,
+    macaroon: macaroon,
+    socket: lndHost
+})
 
 module.exports = lnd;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon ./app",
     "lint": "eslint .",
     "format": "prettier --write '**/*.js'",
-    "test": "mocha --exit tests/"
+    "test": "export NODE_ENV=test && mocha --exit tests/"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
It's a lot simpler to just copy & paste 'tls.cert' & 'admin.macaroon' than having to mess with their contents and expose them as environment variables. The previous method still works though.

The 'tls.cert' and 'admin.macaroon' files were thus added to the .gitignore

Also adds more logs to facilitate troubleshooting.