### PR TITLE
#337 feat(orders): add order expiration time to list orders response

### DIFF
--- a/bot/modules/orders/index.js
+++ b/bot/modules/orders/index.js
@@ -43,7 +43,10 @@ exports.configure = bot => {
       const orders = await ordersActions.getOrders(ctx, ctx.user);
       if (!orders) return false;
 
-      const { text, extra } = await messages.listOrdersResponse(orders);
+      const { text, extra } = await messages.listOrdersResponse(
+        orders,
+        ctx.i18n
+      );
       return ctx.reply(text, extra);
     } catch (error) {
       return logger.error(error);

--- a/bot/modules/orders/messages.js
+++ b/bot/modules/orders/messages.js
@@ -1,7 +1,11 @@
-const { getOrderChannel, sanitizeMD } = require('../../../util');
+const {
+  getOrderChannel,
+  sanitizeMD,
+  getTimeToExpirationOrder,
+} = require('../../../util');
 const logger = require('../../../logger');
 
-exports.listOrdersResponse = async orders => {
+exports.listOrdersResponse = async (orders, i18n) => {
   const tasks = orders.map(async order => {
     const channel = await getOrderChannel(order);
     let amount = '\\-';
@@ -16,10 +20,12 @@ exports.listOrdersResponse = async orders => {
           ].join('');
 
     if (typeof order.amount !== 'undefined') amount = order.amount;
+    const timeToExpire = getTimeToExpirationOrder(order, i18n);
     return [
       [''].join(''),
       ['`Id      `: ', '`', order.id, '`'].join(''),
       ['`Status  `: ', '`', status, '`'].join(''),
+      ['`Time rem`: ', '`', timeToExpire, '`'].join(''),
       ['`Sats amt`: ', '`', amount, '`'].join(''),
       ['`Fiat amt`: ', '`', fiatAmount, '`'].join(''),
       ['`Fiat    `: ', '`', order.fiat_code, '`'].join(''),

--- a/util/index.js
+++ b/util/index.js
@@ -428,6 +428,32 @@ const getUserAge = (user) => {
   return ageInDays
 }
 
+/**
+ * Returns order expiration time text
+ * @param {*} order order object
+ * @param {*} i18n context
+ * @returns String with the remaining time to expiration in format '1 hours 30 minutes'
+ */
+const getTimeToExpirationOrder = (order, i18n) => {
+  const initialDateObj = new Date(order.created_at);
+  const timeToExpire = parseInt(process.env.ORDER_PUBLISHED_EXPIRATION_WINDOW);
+  initialDateObj.setSeconds(initialDateObj.getSeconds() + timeToExpire);
+
+  const currentDateObj = new Date();
+  const timeDifferenceMs = initialDateObj - currentDateObj;
+  const totalSecondsRemaining = Math.floor(timeDifferenceMs / 1000);
+  const textHour = i18n.t('hours');
+  const textMin = i18n.t('minutes');
+
+  if (totalSecondsRemaining <= 0) {
+    return `0 ${textHour} 0 ${textMin}`; // If the date has already passed, show remaining time as 00 hours 00 minutes
+  }
+  // Calculate hours, minutes, and seconds
+  const hours = Math.floor(totalSecondsRemaining / 3600);
+  const minutes = Math.floor((totalSecondsRemaining % 3600) / 60);
+  return `${hours} ${textHour} ${minutes} ${textMin}`;
+};
+
 module.exports = {
   isIso4217,
   plural,

--- a/util/index.js
+++ b/util/index.js
@@ -456,5 +456,6 @@ module.exports = {
   getLanguageFlag,
   delay,
   holdInvoiceExpirationInSecs,
-  getUserAge
+  getUserAge,
+  getTimeToExpirationOrder,
 };


### PR DESCRIPTION
#337 
The `getTimeToExpirationOrder` function works as follows:

- It takes the creation date of the order from the order object and calculates the expiration time by adding the specified `ORDER_PUBLISHED_EXPIRATION_WINDOW` value to the creation date.
- It then calculates the difference between the current date and the expiration date to find the total remaining seconds.
- Using this total remaining time, it calculates the number of hours and minutes remaining and constructs a string in the desired format.
- The function takes an order object and i18n context as inputs and returns a string representing the remaining time in the format "X hours Y minute

Example result:

```
Id      : 64c583074669a3af45b783d0
Status  : PENDING
Time rem: 0 horas 0 minutos
Sats amt: 10000
Fiat amt: 1000
Fiat    : COP
Channel : @test_channel_4534534
_________________________________

Id      : 64c8fcd945aff3bb8395eaa6
Status  : PENDING
Time rem: 0 horas 2 minutos
Sats amt: 0
Fiat amt: 20000
Fiat    : COP
Channel : @test_channel_4534534
_________________________________
```

```
Id      : 64c905112631c9039d53eb1d
Status  : PENDING
Time rem: 22 horas 58 minutos
Sats amt: 0
Fiat amt: 321321
Fiat    : COP
Channel : @test_channel_4534534
_________________________________

Id      : 64c9053c2631c9039d53eb2c
Status  : PENDING
Time rem: 22 horas 59 minutos
Sats amt: 0
Fiat amt: 100
Fiat    : USD
Channel : @test_channel_4534534
_________________________________
```
