### PR TITLE
GitHubCI: enable code-linter at push too

### DIFF
--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -1,7 +1,7 @@
 name: Auto Check Lint
 on:
-  pull_request: 
-    branches: ['main']
+  - pull_request
+  - push
 
 jobs: 
   Lint:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,4 +1,4 @@
-name: integracion continua con node.js
+name: NodeJS Continuous Integration
 
 on: [push, pull_request]
 


### PR DESCRIPTION
And at any branch. This is so that contributors find issues
with their code even before they create a PR.