### PR TITLE
cancel_orders: check created invoices

### DIFF
--- a/jobs/cancel_orders.js
+++ b/jobs/cancel_orders.js
@@ -15,7 +15,15 @@ const cancelOrders = async bot => {
     // or where the buyer didn't add the invoice
     const waitingPaymentOrders = await Order.find({
       $or: [{ status: 'WAITING_PAYMENT' }, { status: 'WAITING_BUYER_INVOICE' }],
-      taken_at: { $lte: holdInvoiceTime },
+      $and: [
+        {
+          taken_at: { $lte: holdInvoiceTime },
+          $or: [
+            { invoice_held_at: { $eq: null } },
+            { invoice_held_at: { $lte: holdInvoiceTime } },
+          ],
+        },
+      ],
     });
     for (const order of waitingPaymentOrders) {
       if (order.status === 'WAITING_PAYMENT') {


### PR DESCRIPTION
Added a new condition to validate the expiration time of orders with the creation time of invoices.

Order will now be deleted if the order has expired and there has been no payment or the payment has been made long ago.

Fixes: https://github.com/lnp2pBot/bot/issues/434