### PR TITLE
Fixes typo in logger info

### DIFF
--- a/ln/resubscribe_invoices.js
+++ b/ln/resubscribe_invoices.js
@@ -29,7 +29,7 @@ const resubscribeInvoices = async bot => {
     }
     logger.info(`Invoices resubscribed: ${invoicesReSubscribed}`);
   } catch (error) {
-    logger.error(`ResuscribeInvoice catch: ${error.toString()}`);
+    logger.error(`ResubcribeInvoice catch: ${error.toString()}`);
     return false;
   }
 };


### PR DESCRIPTION
 New:   logger.info(`Invoices resubscribed: ${invoicesReSubscribed}`)
Old:  New:   logger.info(`Invoices resusscribed: ${invoicesReSubscribed}`)