### PR TITLE
Adds user stats to info command

### DIFF
--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -1137,6 +1137,16 @@ const showInfoMessage = async (ctx: MainContext, user: UserDocument, config: ICo
         parse_mode: 'MarkdownV2',
       }
     );
+    const volume_traded = user.volume_traded
+    const total_rating = user.total_rating
+    const disputes = user.disputes
+    await ctx.telegram.sendMessage(
+      user.tg_id,
+      ctx.i18n.t('user_info', { volume_traded, total_rating, disputes }),
+      {
+        parse_mode: 'MarkdownV2',
+      }
+    );
     // if (status) {
     //   await bot.telegram.sendMessage(user.tg_id, `*Node pubkey*: ${info.public_key}\n`, { parse_mode: "MarkdownV2" });
     // }

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -573,6 +573,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`
 disclaimer: |
   *Mit der Nutzung des P2P-Trade-Bots erklären Sie sich mit den folgenden Bedingungen einverstanden:*
 

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -573,6 +573,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`
 disclaimer: |
   *By using the P2P trade bot, you agree to the following terms and conditions:*
 

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -575,6 +575,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`
 disclaimer: |
   *Al utilizar el bot de comercio P2P, aceptas los siguientes términos y condiciones:*
 

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -573,6 +573,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`
 disclaimer: |
   *En utilisant le bot de commerce P2P, vous acceptez les termes et conditions suivants:*
 

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -570,6 +570,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`
 disclaimer: |
   *Utilizzando il bot per il commercio P2P, si accettano i seguenti termini e condizioni:*
 

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -570,6 +570,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`  
 disclaimer: |
   *Ao utilizar o bot de comércio P2P, o utilizador concorda com os seguintes termos e condições*
 

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -572,6 +572,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`  
 disclaimer: |
   *Используя торгового бота P2P, вы соглашаетесь со следующими условиями:*.
 

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -569,6 +569,10 @@ bot_info: |
   Node URI: `${node_uri}`
   
   Node status: ${status}
+user_info: |
+  Volume traded: ${volume_traded}
+  Total rating: ${total_rating}
+  Disputes: `${disputes}`  
 disclaimer: |
   *Використовуючи P2P торгового бота, ви погоджуєтеся з наступними умовами та положеннями.*
 


### PR DESCRIPTION
Partially solves #182

[As suggested](https://github.com/lnp2pBot/bot/issues/182#issuecomment-1515327553), a new message is appended to the `info` command.

There is no information regarding communities as I didn't see a straightfoward way to fetch it.