### PR TITLE
CI: downgrade to v18

### DIFF
--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 20.x
+          node-version: 18.x
       - run: |
           npm ci
           npm run lint

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 20.x
+          node-version: 18.x
       - name: Update apt and install required packages
         run: |
           sudo apt update

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,7 +64,7 @@ jobs:
         env:
           DB_USER: ''
           DB_PASS: ''
-          DB_HOST: 'localhost'
+          DB_HOST: '127.0.0.1'
           DB_PORT: '27017'
           DB_NAME: 'lnp2pbot'
         run: npm test


### PR DESCRIPTION
The change done in [1] is good because 14.x version was too old, but 20.x is too new. The new Ubunutu LTS, released last month, doesn't even have such a bleeding edge Node version. Let's downgrade to 18.x which is a good sweet spot: new enough, but also stable enough.

This way we make sure LNp2pBot is compatible with the same version of NodeJS shipped by the last Ubuntu LTS.

[1] 439d043b1d0ccee9d1f29c3d3d4513b3fd9ac933