### PR TITLE
commands: inform buyer when order is canceled

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -330,7 +330,7 @@ const cancelAddInvoice = async (ctx, order, job) => {
           );
         }
       } else {
-        await messages.successCancelOrderMessage(ctx, user, order, i18nCtx);
+        await messages.successCancelOrderInvoiceMessage(ctx, user, order, i18nCtx);
       }      
     }
   } catch (error) {

--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -979,6 +979,17 @@ const successCancelOrderMessage = async (ctx: MainContext, user: UserDocument, o
   }
 };
 
+const successCancelOrderInvoiceMessage = async (ctx: MainContext, user: UserDocument, order: IOrder, i18n: I18nContext) => {
+  try {
+    await ctx.telegram.sendMessage(
+      user.tg_id,
+      i18n.t('cancel_invoice', { orderId: order._id })
+    );
+  } catch (error) {
+    logger.error(error);
+  }
+};
+
 const counterPartyCancelOrderMessage = async (ctx: MainContext, user: UserDocument, order: IOrder, i18n: I18nContext) => {
   try {
     await ctx.telegram.sendMessage(
@@ -1681,6 +1692,7 @@ export {
   successCompleteOrderMessage,
   successCancelOrderByAdminMessage,
   successCancelOrderMessage,
+  successCancelOrderInvoiceMessage,
   badStatusOnCancelOrderMessage,
   orderIsAlreadyCanceledMessage,
   invoicePaymentFailedMessage,

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -290,6 +290,7 @@ invoice_already_being_paid: Du hast bereits eine LN-Rechnung für diesen Auftrag
 lightning_address_saved: Lightning-Adresse wurde gespeichert
 cancel_error: Dieser Auftrag kann im Moment nicht storniert werden
 cancel_success: 'Du hast den Auftrag mit der Id ${orderId} storniert!'
+cancel_invoice: 'Die Bestellung ${orderId} wurde storniert, eine Rechnung muss nicht erstellt werden.'
 cancelall_success: Du hast alle deine veröffentlichten Aufträge storniert!
 order_cancelled_by_admin: 'Der Administrator hat den Auftrag mit der ID ${orderId} storniert!'
 order_completed: 'Du hast den Auftrag mit der Id ${orderId} erfolgreich ausgeführt!'

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -292,6 +292,7 @@ invoice_already_being_paid: You have alreday send an invoice for this order and 
 lightning_address_saved: Lightning address has been saved
 cancel_error: This order cannot be cancelled at this moment
 cancel_success: 'You have cancelled the order ID: ${orderId}!'
+cancel_invoice: 'Order ${orderId} has been cancelled, no need to create an invoice.'
 cancelall_success: You have cancelled all your published orders!
 already_cancelled: The order has already been cancelled!
 order_cancelled_by_admin: 'Admin has cancelled the order ID: ${orderId}!'

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -291,6 +291,7 @@ invoice_already_being_paid: Ya has enviado una factura para esta orden y estoy i
 lightning_address_saved: Dirección lightning guardada con éxito
 cancel_error: Esta orden no puede ser cancelada en este momento
 cancel_success: '¡Has cancelado la orden Id: ${orderId}!'
+cancel_invoice: 'La orden ${orderId} se ha cancelado, no es necesarioi crear una factura.'
 cancelall_success: ¡Has cancelado todas tus órdenes publicadas!
 order_cancelled_by_admin: '¡El admin ha cancelado la orden Id: ${orderId}!'
 order_cancelled_by_counterparty: '¡Tu contraparte ha cancelado la orden Id: ${orderId}!'

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -291,6 +291,7 @@ invoice_already_being_paid: Tu as déjà envoyé une facture pour cette commande
 lightning_address_saved: L'adresse Lightning a été enregistrée
 cancel_error: Cette commande ne peut pas être annulée pour le moment
 cancel_success: "Tu as annulé l'offre ID : ${orderId}!"
+cancel_invoice: "La commande ${orderId} a été annulée, il n'est pas nécessaire de créer une facture."
 cancelall_success: Tu as annulé toutes tes commandes publiées !
 order_cancelled_by_admin: "Un Admin a annulé l'offre ID : ${orderId}!"
 order_completed: "Tu as terminé l'offre ID : ${orderId}!"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -290,6 +290,7 @@ invoice_already_being_paid: Hai già inviato una invoice per quest'ordine e sto 
 lightning_address_saved: L'indirizzo lightning è stato salvato
 cancel_error: L'ordine non può essere annullato in questo momento
 cancel_success: "Hai cancellatol'ordine con ID: ${orderId}!"
+cancel_invoice: "L'ordine ${orderId} è stato annullato, non è necessario creare una fattura."
 cancelall_success: Hai canellato tutti gli ordini pubblicati!
 order_cancelled_by_admin: "Un amministratore ha annullato l'ordine ID: ${orderId}!"
 order_cancelled_by_counterparty: "La tua controparte ha annullato l'ordine con ID: ${orderId}!"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -287,6 +287,7 @@ invoice_already_being_paid: 이 주문에 대해 이미 인보이스를 보내�
 lightning_address_saved: 라이트닝 주소가 등록되었습니다.
 cancel_error: 이 주문은 지금은 취소될 수 없습니다.
 cancel_success: '주문 ID: ${orderId}를 취소하였습니다!'
+cancel_invoice: '주문 ${orderId}가 취소되었으므로 인보이스를 생성할 필요가 없습니다.'
 cancelall_success: 등록한 모든 주문들을 취소하였습니다!
 order_cancelled_by_admin: '관리자가 주문 ID: ${orderId}ㄹㄹ 취소하였습니다!'
 order_completed: '주문 ID: ${orderId}가 완료되었습니다!'

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -289,6 +289,7 @@ invoice_already_being_paid: Você já enviou uma fatura para este pedido e estou
 lightning_address_saved: Lightning address foi salvo
 cancel_error: Esta ordem não pode ser cancelada neste momento
 cancel_success: 'Você cancelou o pedido Id: ${orderId}!'
+cancel_invoice: 'A encomenda ${orderId} foi cancelada, não é necessário criar uma fatura.'
 cancelall_success: Você cancelou todos os seus pedidos publicados!
 order_cancelled_by_admin: 'Admin cancelou o pedido Id: ${orderId}!'
 order_completed: 'Você concluiu o pedido Id: ${orderId}!'

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -289,6 +289,7 @@ invoice_already_being_paid: Вы уже отправили счет за эту 
 lightning_address_saved: Aдрес Lightning успешно сохранен.
 cancel_error: Этот заказ не может быть отменен в данный момент
 cancel_success: 'Вы отменили заявку номер ${orderId}!'
+cancel_invoice: 'Заказ ${orderId} был отменен, не нужно создавать счет-фактуру.'
 cancelall_success: Вы отменили все свои размещенные заявки!
 order_cancelled_by_admin: 'Администраторы отменили заявку номер ${orderId}!'
 order_cancelled_by_counterparty: 'Идентификатор отмены заказа вашим контрагентом: ${orderId}!'

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -289,6 +289,7 @@ invoice_already_being_paid: Ви вже відправили рахунок за
 lightning_address_saved: Адреса Lightning успішно збережена.
 cancel_error: На даний момент це замовлення неможливо скасувати
 cancel_success: 'Ви успішно відмінили заявку на номер ${orderId}!'
+cancel_invoice: 'Замовлення ${orderId} було скасовано, немає необхідності створювати інвойс.'
 cancelall_success: 'Ви успішно відмінили всі свої розміщені заявки!'
 order_cancelled_by_admin: 'Адміністратори відмінили заявку за номером ${orderId}!'
 order_cancelled_by_counterparty: 'Ваш контрагент скасував замовлення з ідентифікатором: ${orderId}!'


### PR DESCRIPTION
When the seller cancels an order, the buyer was getting a confusing message:

```
You have cancelled the order ID: orderID
```

Now the bot sends a message that tells the buyer:

```
Order orderId has been cancelled. There is no need to create an invoice.
```

Fixes: https://github.com/lnp2pBot/bot/issues/482