### PR TITLE
messages: CommonJS require to TypeScript import

### DIFF
--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -1,5 +1,5 @@
-const { TelegramError } = require('telegraf');
-const QR = require('qrcode');
+import { TelegramError } from 'telegraf'
+import QR from 'qrcode';
 const {
   getCurrency,
   numberFormat,
@@ -14,7 +14,7 @@ const {
   getStars,
 } = require('../util');
 const OrderEvents = require('./modules/events/orders');
-const { logger } = require('../logger');
+import { logger } from "../logger";
 import { MainContext } from './start';
 import { UserDocument } from '../models/user'
 import { IOrder } from '../models/order'
@@ -103,7 +103,7 @@ const invoicePaymentRequestMessage = async (
   }
 };
 
-const pendingSellMessage = async (ctx: MainContext, user: UserDocument, order: IOrder, channel: string, i18n: I18nContext) => {
+const pendingSellMessage = async (ctx: Telegraf<MainContext>, user: UserDocument, order: IOrder, channel: string, i18n: I18nContext) => {
   try {
     const orderExpirationWindow =
       Number(process.env.ORDER_PUBLISHED_EXPIRATION_WINDOW) / 60 / 60;
@@ -614,7 +614,7 @@ const publishBuyOrderMessage = async (
 };
 
 const publishSellOrderMessage = async (
-  ctx: MainContext,
+  ctx: Telegraf<MainContext>,
   user: UserDocument,
   order: IOrder,
   i18n: I18nContext,
@@ -1553,7 +1553,7 @@ const currencyNotSupportedMessage = async (ctx: MainContext, currencies: Array<s
   }
 };
 
-const notAuthorized = async (ctx: MainContext, tgId: string) => {
+const notAuthorized = async (ctx: MainContext, tgId?: string) => {
   try {
     if (tgId) {
       await ctx.telegram.sendMessage(tgId, ctx.i18n.t('not_authorized'));
@@ -1610,7 +1610,7 @@ const showConfirmationButtons = async (ctx: MainContext, orders: Array<IOrder>, 
   }
 };
 
-module.exports = {
+export {
   startMessage,
   initBotErrorMessage,
   invoicePaymentRequestMessage,

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -54,7 +54,7 @@ const {
   validateObjectId,
   validateLightningAddress,
 } = require('./validations');
-const messages = require('./messages');
+import * as messages from './messages';
 const {
   attemptPendingPayments,
   cancelOrders,

--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -1,6 +1,6 @@
 const { payRequest, isPendingPayment } = require('../ln');
 const { PendingPayment, Order, User, Community } = require('../models');
-const messages = require('../bot/messages');
+import * as messages from '../bot/messages';
 const { getUserI18nContext } = require('../util');
 const { logger } = require('../logger');
 import { Telegraf } from 'telegraf';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lnp2pbot",
-  "version": "0.10.2",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lnp2pbot",
-      "version": "0.10.2",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
         "@grammyjs/i18n": "^0.5.1",
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.5.0",
+        "@types/qrcode": "^1.5.2",
         "chai": "^4.3.4",
         "chokidar": "^3.5.3",
         "eslint": "^8.15.0",
@@ -1647,6 +1648,15 @@
       "version": "20.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
       "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q=="
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.5.tgz",
+      "integrity": "sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "devDependencies": {
     "@types/node": "^20.5.0",
+    "@types/qrcode": "^1.5.2",
     "chai": "^4.3.4",
     "chokidar": "^3.5.3",
     "eslint": "^8.15.0",


### PR DESCRIPTION
This commit completes the TypeScript conversion [1] by replacing
the CommonJS `require` syntax with TypeScript's `import` syntax.

[1]: https://github.com/lnp2pBot/bot/pull/435