### PR TITLE
Show the previous Status to DISPUTE in dispute message for solvers

### DIFF
--- a/bot/modules/dispute/commands.js
+++ b/bot/modules/dispute/commands.js
@@ -35,6 +35,7 @@ const dispute = async ctx => {
     if (user._id == order.buyer_id) initiator = 'buyer';
 
     order[`${initiator}_dispute`] = true;
+    order.previous_dispute_status = order.status
     order.status = 'DISPUTE';
     const sellerToken = Math.floor(Math.random() * 899 + 100);
     const buyerToken = Math.floor(Math.random() * 899 + 100);

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -156,6 +156,8 @@ buy_sats: Kaufe Sats
 order_detail: |
   Id: `${order._id}`
 
+  Status previous to dispute: ${previousDisputeStatus}
+
   Status: ${status}
 
   Ersteller: @${creator || ''}

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -158,6 +158,8 @@ buy_sats: Buy satoshis
 order_detail: |
   ID: `${order._id}`
 
+  Status previous to dispute: ${previousDisputeStatus}
+  
   Status: ${status}
 
   Creator: @${creator || ''}

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -155,7 +155,9 @@ sell_sats: Vender satoshis
 buy_sats: Comprar satoshis
 order_detail: |
   Id: `${order._id}`
-
+  
+  Status previo a disputa: ${previousDisputeStatus}
+  
   Status: ${status}
 
   Creador: @${creator || ''}

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -158,6 +158,8 @@ buy_sats: خرید ساتوشی
 order_detail: |
   ID: `${order._id}`
 
+  Status previous to dispute: ${previousDisputeStatus}
+
   Status: ${status}
 
   Creator: @${creator || ''}

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -158,6 +158,8 @@ buy_sats: Achète des satoshis
 order_detail: |
   ID : `${order._id}`
 
+  Situation antérieure au litige: ${previousDisputeStatus}
+
   Statut : ${status}
 
   Créateur : @${creator || ''}

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -156,6 +156,8 @@ buy_sats: Compra satoshis
 order_detail: |
   Id: `${order._id}`
 
+  Stato precedente alla controversia: ${previousDisputeStatus}
+
   Stato: ${status}
 
   Creato da: @${creator || ''}

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -157,6 +157,8 @@ buy_sats: 비트코인 구매
 order_detail: |
   ID: `${order._id}`
 
+  Status previous to dispute: ${previousDisputeStatus}
+
   상태: ${status}
 
   생성자: @${creator || ''}

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -155,6 +155,8 @@ buy_sats: Compre Satoshis
 order_detail: |
   Id: `${order._id}`
 
+  Situação anterior ao litígio: ${previousDisputeStatus}
+
   Status: ${status}
 
   Criadora: @${creator || ''}

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -154,6 +154,8 @@ sell_sats: Продать сатоши
 buy_sats: Купить сатоши
 order_detail: |
   Id: `${order._id}`
+  
+  Status previous to dispute: ${previousDisputeStatus}
 
   Статус: ${status}
 

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -154,6 +154,8 @@ sell_sats: Продати сатоші
 buy_sats: Купити сатоші
 order_detail: |
   Id: `${order._id}`
+  
+  Status previous to dispute: ${previousDisputeStatus}
 
   Статус: ${status}
 

--- a/models/order.ts
+++ b/models/order.ts
@@ -23,6 +23,7 @@ export interface IOrder extends Document {
   seller_cooperativecancel: boolean;
   canceled_by: string
   action_by: string
+  previous_dispute_status: string;
   status: string;
   type: string;
   fiat_amount: number;
@@ -92,6 +93,13 @@ const orderSchema = new Schema<IOrder>({
   seller_cooperativecancel: { type: Boolean, default: false },
   canceled_by: { type: String },
   action_by: { type: String },
+  previous_dispute_status: {
+    type: String,
+    enum: [
+      'ACTIVE', //  order taken
+      'FIAT_SENT', // buyer indicates the fiat payment is already done
+    ],
+  },
   status: {
     type: String,
     enum: [

--- a/util/index.js
+++ b/util/index.js
@@ -361,6 +361,7 @@ exports.getDetailedOrder = (i18n, order, buyer, seller) => {
     let takenAt = order.taken_at ? order.taken_at.toISOString() : '';
     createdAt = sanitizeMD(createdAt);
     takenAt = sanitizeMD(takenAt);
+    const previousDisputeStatus = sanitizeMD(order.previous_dispute_status);
     const status = sanitizeMD(order.status);
     const fee = order.fee ? parseInt(order.fee) : '';
     const creator =
@@ -376,6 +377,7 @@ exports.getDetailedOrder = (i18n, order, buyer, seller) => {
       sellerUsername,
       createdAt,
       takenAt,
+      previousDisputeStatus,
       status,
       fee,
       paymentMethod,


### PR DESCRIPTION
Added the message 'Status previous to dispute' in the dispute message that informs the solver about the order.

I added the message in all the languages, but in the ones I could not translate I left the message in english, please confirm if this is ok or I have to change something.

Fix #418 