### PR TITLE
small fix cup currency

### DIFF
--- a/util/fiat.json
+++ b/util/fiat.json
@@ -311,7 +311,7 @@
   "CUP": {
     "symbol": "CU$",
     "name": "Peso cubano",
-    "symbol_native": "$",
+    "symbol_native": "CUP",
     "decimal_digits": 2,
     "rounding": 0,
     "code": "CUP",


### PR DESCRIPTION
En Cuba nunca usamos el símbolo de $ para referirnos al CUP.
De la forma en que estaba salía, p.ej:  ¨Por favor paga esta factura de 3700 sats equivalente a **$ 700** para comenzar la operación.¨ y eso puede confundir a los más nuevos, pues sería 700 CUP.