### PR TITLE
fix solver username

### DIFF
--- a/bot/modules/dispute/messages.js
+++ b/bot/modules/dispute/messages.js
@@ -119,14 +119,14 @@ exports.disputeData = async (
     await ctx.telegram.sendMessage(
       buyer.tg_id,
       ctx.i18n.t('dispute_solver', {
-        solver: sanitizeMD(solver.username),
+        solver: solver.username,
         token: order.buyer_dispute_token,
       })
     );
     await ctx.telegram.sendMessage(
       seller.tg_id,
       ctx.i18n.t('dispute_solver', {
-        solver: sanitizeMD(solver.username),
+        solver: solver.username,
         token: order.seller_dispute_token,
       })
     );


### PR DESCRIPTION
To fix:
If an admin has an underscore in their username e.g. `@Abc_xyz`, when they take a dispute the users will get the wrong username, e.g.:
`tapping his/her username => @Abc\_xyz <=`

(this doesn't happen in production, but in development on the main branch)