### PR TITLE
Introduces 'dist' dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .env
 admin.macaroon
 tls.cert
+dist/

--- a/bot/validations.ts
+++ b/bot/validations.ts
@@ -691,7 +691,7 @@ const isBannedFromCommunity = async (user: UserDocument, communityId: string) =>
   }
 };
 
-module.exports = {
+export {
   validateSellOrder,
   validateBuyOrder,
   validateUser,

--- a/models/community.ts
+++ b/models/community.ts
@@ -41,6 +41,7 @@ export interface ICommunity extends Document {
     order_channels: Types.DocumentArray<IOrderChannel>;
     fee: number;
     earnings: number;
+    orders: number;
     orders_to_redeem: number;
     dispute_channel: string;
     solvers: Types.DocumentArray<IUsernameId>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,50 +174,50 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.658.1.tgz",
-      "integrity": "sha512-MCYLKmNy0FlNT9TvXfOxj0jh+ZQq+G9qEy/VZqu3JsQSgiFvFRdzgzcbQ9gQx7fZrDC/TPdABOTh483zI4cu9g==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.687.0.tgz",
+      "integrity": "sha512-jcQTioloSed+Jc3snjrgpWejkOm8t3Zt+jWrApw3ejN8qBtpFCH43M7q/CSDVZ9RS1IjX+KRWoBFnrDOnbuw0Q==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.658.1",
-        "@aws-sdk/client-sts": "3.658.1",
-        "@aws-sdk/core": "3.658.1",
-        "@aws-sdk/credential-provider-node": "3.658.1",
-        "@aws-sdk/middleware-host-header": "3.654.0",
-        "@aws-sdk/middleware-logger": "3.654.0",
-        "@aws-sdk/middleware-recursion-detection": "3.654.0",
-        "@aws-sdk/middleware-user-agent": "3.654.0",
-        "@aws-sdk/region-config-resolver": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@aws-sdk/util-endpoints": "3.654.0",
-        "@aws-sdk/util-user-agent-browser": "3.654.0",
-        "@aws-sdk/util-user-agent-node": "3.654.0",
-        "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.6",
-        "@smithy/fetch-http-handler": "^3.2.8",
-        "@smithy/hash-node": "^3.0.6",
-        "@smithy/invalid-dependency": "^3.0.6",
-        "@smithy/middleware-content-length": "^3.0.8",
-        "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.21",
-        "@smithy/middleware-serde": "^3.0.6",
-        "@smithy/middleware-stack": "^3.0.6",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.3",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
-        "@smithy/url-parser": "^3.0.6",
+        "@aws-sdk/client-sso-oidc": "3.687.0",
+        "@aws-sdk/client-sts": "3.687.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.687.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.687.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.687.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.21",
-        "@smithy/util-defaults-mode-node": "^3.0.21",
-        "@smithy/util-endpoints": "^2.1.2",
-        "@smithy/util-middleware": "^3.0.6",
-        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -226,47 +226,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.658.1.tgz",
-      "integrity": "sha512-lOuaBtqPTYGn6xpXlQF4LsNDsQ8Ij2kOdnk+i69Kp6yS76TYvtUuukyLL5kx8zE1c8WbYtxj9y8VNw9/6uKl7Q==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.687.0.tgz",
+      "integrity": "sha512-dfj0y9fQyX4kFill/ZG0BqBTLQILKlL7+O5M4F9xlsh2WNuV2St6WtcOg14Y1j5UODPJiJs//pO+mD1lihT5Kw==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.658.1",
-        "@aws-sdk/middleware-host-header": "3.654.0",
-        "@aws-sdk/middleware-logger": "3.654.0",
-        "@aws-sdk/middleware-recursion-detection": "3.654.0",
-        "@aws-sdk/middleware-user-agent": "3.654.0",
-        "@aws-sdk/region-config-resolver": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@aws-sdk/util-endpoints": "3.654.0",
-        "@aws-sdk/util-user-agent-browser": "3.654.0",
-        "@aws-sdk/util-user-agent-node": "3.654.0",
-        "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.6",
-        "@smithy/fetch-http-handler": "^3.2.8",
-        "@smithy/hash-node": "^3.0.6",
-        "@smithy/invalid-dependency": "^3.0.6",
-        "@smithy/middleware-content-length": "^3.0.8",
-        "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.21",
-        "@smithy/middleware-serde": "^3.0.6",
-        "@smithy/middleware-stack": "^3.0.6",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.3",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
-        "@smithy/url-parser": "^3.0.6",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.687.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.687.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.21",
-        "@smithy/util-defaults-mode-node": "^3.0.21",
-        "@smithy/util-endpoints": "^2.1.2",
-        "@smithy/util-middleware": "^3.0.6",
-        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -275,48 +275,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.658.1.tgz",
-      "integrity": "sha512-RGcZAI3qEA05JszPKwa0cAyp8rnS1nUvs0Sqw4hqLNQ1kD7b7V6CPjRXe7EFQqCOMvM4kGqx0+cEEVTOmBsFLw==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.687.0.tgz",
+      "integrity": "sha512-Rdd8kLeTeh+L5ZuG4WQnWgYgdv7NorytKdZsGjiag1D8Wv3PcJvPqqWdgnI0Og717BSXVoaTYaN34FyqFYSx6Q==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.658.1",
-        "@aws-sdk/credential-provider-node": "3.658.1",
-        "@aws-sdk/middleware-host-header": "3.654.0",
-        "@aws-sdk/middleware-logger": "3.654.0",
-        "@aws-sdk/middleware-recursion-detection": "3.654.0",
-        "@aws-sdk/middleware-user-agent": "3.654.0",
-        "@aws-sdk/region-config-resolver": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@aws-sdk/util-endpoints": "3.654.0",
-        "@aws-sdk/util-user-agent-browser": "3.654.0",
-        "@aws-sdk/util-user-agent-node": "3.654.0",
-        "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.6",
-        "@smithy/fetch-http-handler": "^3.2.8",
-        "@smithy/hash-node": "^3.0.6",
-        "@smithy/invalid-dependency": "^3.0.6",
-        "@smithy/middleware-content-length": "^3.0.8",
-        "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.21",
-        "@smithy/middleware-serde": "^3.0.6",
-        "@smithy/middleware-stack": "^3.0.6",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.3",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
-        "@smithy/url-parser": "^3.0.6",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.687.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.687.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.687.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.21",
-        "@smithy/util-defaults-mode-node": "^3.0.21",
-        "@smithy/util-endpoints": "^2.1.2",
-        "@smithy/util-middleware": "^3.0.6",
-        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -324,53 +324,53 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.658.1"
+        "@aws-sdk/client-sts": "^3.687.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.658.1.tgz",
-      "integrity": "sha512-yw9hc5blTnbT1V6mR7Cx9HGc9KQpcLQ1QXj8rntiJi6tIYu3aFNVEyy81JHL7NsuBSeQulJTvHO3y6r3O0sfRg==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.687.0.tgz",
+      "integrity": "sha512-SQjDH8O4XCTtouuCVYggB0cCCrIaTzUZIkgJUpOsIEJBLlTbNOb/BZqUShAQw2o9vxr2rCeOGjAQOYPysW/Pmg==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.658.1",
-        "@aws-sdk/core": "3.658.1",
-        "@aws-sdk/credential-provider-node": "3.658.1",
-        "@aws-sdk/middleware-host-header": "3.654.0",
-        "@aws-sdk/middleware-logger": "3.654.0",
-        "@aws-sdk/middleware-recursion-detection": "3.654.0",
-        "@aws-sdk/middleware-user-agent": "3.654.0",
-        "@aws-sdk/region-config-resolver": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@aws-sdk/util-endpoints": "3.654.0",
-        "@aws-sdk/util-user-agent-browser": "3.654.0",
-        "@aws-sdk/util-user-agent-node": "3.654.0",
-        "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.6",
-        "@smithy/fetch-http-handler": "^3.2.8",
-        "@smithy/hash-node": "^3.0.6",
-        "@smithy/invalid-dependency": "^3.0.6",
-        "@smithy/middleware-content-length": "^3.0.8",
-        "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.21",
-        "@smithy/middleware-serde": "^3.0.6",
-        "@smithy/middleware-stack": "^3.0.6",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.3",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
-        "@smithy/url-parser": "^3.0.6",
+        "@aws-sdk/client-sso-oidc": "3.687.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.687.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.687.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.687.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.21",
-        "@smithy/util-defaults-mode-node": "^3.0.21",
-        "@smithy/util-endpoints": "^2.1.2",
-        "@smithy/util-middleware": "^3.0.6",
-        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -379,19 +379,20 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.658.1.tgz",
-      "integrity": "sha512-vJVMoMcSKXK2gBRSu9Ywwv6wQ7tXH8VL1fqB1uVxgCqBZ3IHfqNn4zvpMPWrwgO2/3wv7XFyikGQ5ypPTCw4jA==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+      "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
       "optional": true,
       "dependencies": {
-        "@smithy/core": "^2.4.6",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/signature-v4": "^4.1.4",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
-        "@smithy/util-middleware": "^3.0.6",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -400,15 +401,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.658.1.tgz",
-      "integrity": "sha512-JY4rZ4e2emL7PNHCU7F/BQV8PpQGEBZLkEoPD55RO4CitaIhlVZRpUCGLih+0Hw4MOnTUqJdfQBM+qZk6G+Now==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.687.0.tgz",
+      "integrity": "sha512-hJq9ytoj2q/Jonc7mox/b0HT+j4NeMRuU184DkXRJbvIvwwB+oMt12221kThLezMhwIYfXEteZ7GEId7Hn8Y8g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.658.1",
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/client-cognito-identity": "3.687.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -416,14 +417,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.654.0.tgz",
-      "integrity": "sha512-kogsx3Ql81JouHS7DkheCDU9MYAvK0AokxjcshDveGmf7BbgbWCA8Fnb9wjQyNDaOXNvkZu8Z8rgkX91z324/w==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+      "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -431,19 +433,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.658.1.tgz",
-      "integrity": "sha512-4ubkJjEVCZflxkZnV1JDQv8P2pburxk1LrEp55telfJRzXrnowzBKwuV2ED0QMNC448g2B3VCaffS+Ct7c4IWQ==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+      "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/fetch-http-handler": "^3.2.8",
-        "@smithy/node-http-handler": "^3.2.3",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
-        "@smithy/util-stream": "^3.1.8",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -451,47 +454,48 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.658.1.tgz",
-      "integrity": "sha512-2uwOamQg5ppwfegwen1ddPu5HM3/IBSnaGlaKLFhltkdtZ0jiqTZWUtX2V+4Q+buLnT0hQvLS/frQ+7QUam+0Q==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.687.0.tgz",
+      "integrity": "sha512-6d5ZJeZch+ZosJccksN0PuXv7OSnYEmanGCnbhUqmUSz9uaVX6knZZfHCZJRgNcfSqg9QC0zsFA/51W5HCUqSQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.654.0",
-        "@aws-sdk/credential-provider-http": "3.658.1",
-        "@aws-sdk/credential-provider-process": "3.654.0",
-        "@aws-sdk/credential-provider-sso": "3.658.1",
-        "@aws-sdk/credential-provider-web-identity": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/credential-provider-imds": "^3.2.3",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/shared-ini-file-loader": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.687.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.658.1"
+        "@aws-sdk/client-sts": "^3.687.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.658.1.tgz",
-      "integrity": "sha512-XwxW6N+uPXPYAuyq+GfOEdfL/MZGAlCSfB5gEWtLBFmFbikhmEuqfWtI6CD60OwudCUOh6argd21BsJf8o1SJA==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.687.0.tgz",
+      "integrity": "sha512-Pqld8Nx11NYaBUrVk3bYiGGpLCxkz8iTONlpQWoVWFhSOzlO7zloNOaYbD2XgFjjqhjlKzE91drs/f41uGeCTA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.654.0",
-        "@aws-sdk/credential-provider-http": "3.658.1",
-        "@aws-sdk/credential-provider-ini": "3.658.1",
-        "@aws-sdk/credential-provider-process": "3.654.0",
-        "@aws-sdk/credential-provider-sso": "3.658.1",
-        "@aws-sdk/credential-provider-web-identity": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/credential-provider-imds": "^3.2.3",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/shared-ini-file-loader": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-ini": "3.687.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.687.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -499,15 +503,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.654.0.tgz",
-      "integrity": "sha512-PmQoo8sZ9Q2Ow8OMzK++Z9lI7MsRUG7sNq3E72DVA215dhtTICTDQwGlXH2AAmIp7n+G9LLRds+4wo2ehG4mkg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+      "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/shared-ini-file-loader": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -515,17 +520,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.658.1.tgz",
-      "integrity": "sha512-YOagVEsZEk9DmgJEBg+4MBXrPcw/tYas0VQ5OVBqC5XHNbi2OBGJqgmjVPesuu393E7W0VQxtJFDS00O1ewQgA==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.687.0.tgz",
+      "integrity": "sha512-N1YCoE7DovIRF2ReyRrA4PZzF0WNi4ObPwdQQkVxhvSm7PwjbWxrfq7rpYB+6YB1Uq3QPzgVwUFONE36rdpxUQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.658.1",
-        "@aws-sdk/token-providers": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/shared-ini-file-loader": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/client-sso": "3.687.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/token-providers": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -533,44 +539,46 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.654.0.tgz",
-      "integrity": "sha512-6a2g9gMtZToqSu+CusjNK5zvbLJahQ9di7buO3iXgbizXpLXU1rnawCpWxwslMpT5fLgMSKDnKDrr6wdEk7jSw==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+      "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.654.0"
+        "@aws-sdk/client-sts": "^3.686.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.658.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.658.1.tgz",
-      "integrity": "sha512-lfXA6kZS6GHyi/67EbfrKdLoqHR6j7G35eFwaqxyNkfMhNBpAF0eZK3SYiwnzdR9+Wb/enTFawYiFbG5R+dQzA==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.687.0.tgz",
+      "integrity": "sha512-3aKlmKaOplpanOycmoigbTrQsqtxpzhpfquCey51aHf9GYp2yYyYF1YOgkXpE3qm3w6eiEN1asjJ2gqoECUuPA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.658.1",
-        "@aws-sdk/client-sso": "3.658.1",
-        "@aws-sdk/client-sts": "3.658.1",
-        "@aws-sdk/credential-provider-cognito-identity": "3.658.1",
-        "@aws-sdk/credential-provider-env": "3.654.0",
-        "@aws-sdk/credential-provider-http": "3.658.1",
-        "@aws-sdk/credential-provider-ini": "3.658.1",
-        "@aws-sdk/credential-provider-node": "3.658.1",
-        "@aws-sdk/credential-provider-process": "3.654.0",
-        "@aws-sdk/credential-provider-sso": "3.658.1",
-        "@aws-sdk/credential-provider-web-identity": "3.654.0",
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/credential-provider-imds": "^3.2.3",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/client-cognito-identity": "3.687.0",
+        "@aws-sdk/client-sso": "3.687.0",
+        "@aws-sdk/client-sts": "3.687.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.687.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-ini": "3.687.0",
+        "@aws-sdk/credential-provider-node": "3.687.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.687.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -578,14 +586,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.654.0.tgz",
-      "integrity": "sha512-rxGgVHWKp8U2ubMv+t+vlIk7QYUaRCHaVpmUlJv0Wv6Q0KeO9a42T9FxHphjOTlCGQOLcjCreL9CF8Qhtb4mdQ==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+      "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -593,13 +601,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.654.0.tgz",
-      "integrity": "sha512-OQYb+nWlmASyXfRb989pwkJ9EVUMP1CrKn2eyTk3usl20JZmKo2Vjis6I0tLUkMSxMhnBJJlQKyWkRpD/u1FVg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+      "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -607,14 +615,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.654.0.tgz",
-      "integrity": "sha512-gKSomgltKVmsT8sC6W7CrADZ4GHwX9epk3GcH6QhebVO3LA9LRbkL3TwOPUXakxxOLLUTYdOZLIOtFf7iH00lg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+      "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -622,15 +630,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.654.0.tgz",
-      "integrity": "sha512-liCcqPAyRsr53cy2tYu4qeH4MMN0eh9g6k56XzI5xd4SghXH5YWh4qOYAlQ8T66ZV4nPMtD8GLtLXGzsH8moFg==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.687.0.tgz",
+      "integrity": "sha512-nUgsKiEinyA50CaDXojAkOasAU3Apdg7Qox6IjNUC4ZjgOu7QWsCDB5N28AYMUt06cNYeYQdfMX1aEzG85a1Mg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@aws-sdk/util-endpoints": "3.654.0",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -638,16 +648,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.654.0.tgz",
-      "integrity": "sha512-ydGOrXJxj3x0sJhsXyTmvJVLAE0xxuTWFJihTl67RtaO7VRNtd82I3P3bwoMMaDn5WpmV5mPo8fEUDRlBm3fPg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+      "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -655,31 +665,31 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.654.0.tgz",
-      "integrity": "sha512-D8GeJYmvbfWkQDtTB4owmIobSMexZel0fOoetwvgCQ/7L8VPph3Q2bn1TRRIXvH7wdt6DcDxA3tKMHPBkT3GlA==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+      "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/shared-ini-file-loader": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.654.0"
+        "@aws-sdk/client-sso-oidc": "^3.686.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
-      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -687,14 +697,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.654.0.tgz",
-      "integrity": "sha512-i902fcBknHs0Irgdpi62+QMvzxE+bczvILXigYrlHL4+PiEnlMVpni5L5W1qCkNZXf8AaMrSBuR1NZAGp6UOUw==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+      "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/types": "^3.4.2",
-        "@smithy/util-endpoints": "^2.1.2",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-endpoints": "^2.1.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -702,9 +712,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.568.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
-      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.679.0.tgz",
+      "integrity": "sha512-zKTd48/ZWrCplkXpYDABI74rQlbR0DNHs8nH95htfSLj9/mWRSwaGptoxwcihaq/77vi/fl2X3y0a1Bo8bt7RA==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -714,26 +724,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.654.0.tgz",
-      "integrity": "sha512-ykYAJqvnxLt7wfrqya28wuH3/7NdrwzfiFd7NqEVQf7dXVxL5RPEpD7DxjcyQo3DsHvvdUvGZVaQhozycn1pzA==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+      "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.654.0.tgz",
-      "integrity": "sha512-a0ojjdBN6pqv6gB4H/QPPSfhs7mFtlVwnmKCM/QrTaFzN0U810PJ1BST3lBx5sa23I5jWHGaoFY+5q65C3clLQ==",
+      "version": "3.687.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.687.0.tgz",
+      "integrity": "sha512-idkP6ojSTZ4ek1pJ8wIN7r9U3KR5dn0IkJn3KQBXQ58LWjkRqLtft2vxzdsktWwhPKjjmIKl1S0kbvqLawf8XQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.654.0",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@aws-sdk/middleware-user-agent": "3.687.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -767,24 +778,27 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1142,12 +1156,12 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.4.tgz",
-      "integrity": "sha512-VupaALAQlXViW3/enTf/f5l5JZYSAxoJL7f0nanhNNKnww6DGCg1oYIuNP78KDugnkwthBO6iEcym16HhWV8RQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
+      "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1155,15 +1169,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.8.tgz",
-      "integrity": "sha512-Tv1obAC18XOd2OnDAjSWmmthzx6Pdeh63FbLin8MlPiuJ2ATpKkq0NcNOJFr0dO+JmZXnwu8FQxKJ3TKJ3Hulw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
+      "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1171,19 +1185,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.6.tgz",
-      "integrity": "sha512-6lQQp99hnyuNNIzeTYSzCUXJHwvvFLY7hfdFGSJM95tjRDJGfzWYFRBXPaM9766LiiTsQ561KErtbufzUFSYUg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-DujtuDA7BGEKExJ05W5OdxCoyekcKT3Rhg1ZGeiUWaz2BJIWXjZmsG/DIP4W48GHno7AQwRsaCb8NcBgH3QZpg==",
       "optional": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.21",
-        "@smithy/middleware-serde": "^3.0.6",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -1192,15 +1204,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.3.tgz",
-      "integrity": "sha512-VoxMzSzdvkkjMJNE38yQgx4CfnmT+Z+5EUXkg4x7yag93eQkVQgZvN3XBSHC/ylfBbLbAtdu7flTCChX9I+mVg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.5.tgz",
+      "integrity": "sha512-4FTQGAsuwqTzVMmiRVTn0RR9GrbRfkP0wfu/tXWVHd2LgNpTY0uglQpIScXK4NaEyXbB3JmZt8gfVqO50lP8wg==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/types": "^3.4.2",
-        "@smithy/url-parser": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1208,25 +1220,25 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.8.tgz",
-      "integrity": "sha512-Lqe0B8F5RM7zkw//6avq1SJ8AfaRd3ubFUS1eVp5WszV7p6Ne5hQ4dSuMHDpNRPhgTvj4va9Kd/pcVigHEHRow==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
       "optional": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/querystring-builder": "^3.0.6",
-        "@smithy/types": "^3.4.2",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.6.tgz",
-      "integrity": "sha512-c/FHEdKK/7DU2z6ZE91L36ahyXWayR3B+FzELjnYq7wH5YqIseM24V+pWCS9kFn1Ln8OFGTf+pyYPiHZuX0s/Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
+      "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -1236,12 +1248,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.6.tgz",
-      "integrity": "sha512-czM7Ioq3s8pIXht7oD+vmgy4Wfb4XavU/k/irO8NdXFFOx7YAlsCCcKOh/lJD1mJSYQqiR7NmpZ9JviryD/7AQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.8.tgz",
+      "integrity": "sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -1258,13 +1270,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.8.tgz",
-      "integrity": "sha512-VuyszlSO49WKh3H9/kIO2kf07VUwGV80QRiaDxUfP8P8UKlokz381ETJvwLhwuypBYhLymCYyNhB3fLAGBX2og==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
+      "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
       "optional": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/types": "^3.4.2",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1272,17 +1284,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.3.tgz",
-      "integrity": "sha512-KeM/OrK8MVFUsoJsmCN0MZMVPjKKLudn13xpgwIMpGTYpA8QZB2Xq5tJ+RE6iu3A6NhOI4VajDTwBsm8pwwrhg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.1.tgz",
+      "integrity": "sha512-wWO3xYmFm6WRW8VsEJ5oU6h7aosFXfszlz3Dj176pTij6o21oZnzkCLzShfmRaaCHDkBXWBdO0c4sQAvLFP6zA==",
       "optional": true,
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.6",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.7",
-        "@smithy/types": "^3.4.2",
-        "@smithy/url-parser": "^3.0.6",
-        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1290,18 +1303,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.21.tgz",
-      "integrity": "sha512-/h0fElV95LekVVEJuSw+aI11S1Y3zIUwBc6h9ZbUv43Gl2weXsbQwjLoet6j/Qtb0phfrSxS6pNg6FqgJOWZkA==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
+      "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/service-error-classification": "^3.0.6",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
-        "@smithy/util-middleware": "^3.0.6",
-        "@smithy/util-retry": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -1310,12 +1323,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.6.tgz",
-      "integrity": "sha512-KKTUSl1MzOM0MAjGbudeaVNtIDo+PpekTBkCNwvfZlKndodrnvRo+00USatiyLOc0ujjO9UydMRu3O9dYML7ag==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
+      "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1323,12 +1336,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.6.tgz",
-      "integrity": "sha512-2c0eSYhTQ8xQqHMcRxLMpadFbTXg6Zla5l0mwNftFCZMQmuhI7EbAJMx6R5eqfuV3YbJ3QGyS3d5uSmrHV8Khg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
+      "integrity": "sha512-d7ZuwvYgp1+3682Nx0MD3D/HtkmZd49N3JUndYWQXfRZrYEnCWYc8BHcNmVsPAp9gKvlurdg/mubE6b/rPS9MA==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1336,14 +1349,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.7.tgz",
-      "integrity": "sha512-g3mfnC3Oo8pOI0dYuPXLtdW1WGVb3bR2tkV21GNkm0ZvQjLTtamXAwCWt/FCb0HGvKt3gHHmF1XerG0ICfalOg==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "optional": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/shared-ini-file-loader": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1351,15 +1364,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.3.tgz",
-      "integrity": "sha512-/gcm5DJ3k1b1zEInzBGAZC8ntJ+jwrz1NcSIu+9dSXd1FfG0G6QgkDI40tt8/WYUbHtLyo8fEqtm2v29koWo/w==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+      "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
       "optional": true,
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/querystring-builder": "^3.0.6",
-        "@smithy/types": "^3.4.2",
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1367,12 +1380,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.6.tgz",
-      "integrity": "sha512-NK3y/T7Q/Bw+Z8vsVs9MYIQ5v7gOX7clyrXcwhhIBQhbPgRl6JDrZbusO9qWDhcEus75Tg+VCxtIRfo3H76fpw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+      "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1380,12 +1393,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.3.tgz",
-      "integrity": "sha512-GcbMmOYpH9iRqtC05RbRnc/0FssxSTHlmaNhYBTgSgNCYpdR3Kt88u5GAZTBmouzv+Zlj/VRv92J9ruuDeJuEw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+      "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1393,12 +1406,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.6.tgz",
-      "integrity": "sha512-sQe08RunoObe+Usujn9+R2zrLuQERi3CWvRO3BvnoWSYUaIrLKuAIeY7cMeDax6xGyfIP3x/yFWbEKSXvOnvVg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
+      "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -1407,12 +1420,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.6.tgz",
-      "integrity": "sha512-UJKw4LlEkytzz2Wq+uIdHf6qOtFfee/o7ruH0jF5I6UAuU+19r9QV7nU3P/uI0l6+oElRHmG/5cBBcGJrD7Ozg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
+      "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1420,24 +1433,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.6.tgz",
-      "integrity": "sha512-53SpchU3+DUZrN7J6sBx9tBiCVGzsib2e4sc512Q7K9fpC5zkJKs6Z9s+qbMxSYrkEkle6hnMtrts7XNkMJJMg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
+      "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2"
+        "@smithy/types": "^3.6.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.7.tgz",
-      "integrity": "sha512-IA4K2qTJYXkF5OfVN4vsY1hfnUZjaslEE8Fsr/gGFza4TAC2A9NfnZuSY2srQIbt9bwtjHiAayrRVgKse4Q7fA==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1445,16 +1458,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
-      "integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
       "optional": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/types": "^3.4.2",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.8",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -1464,16 +1477,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.5.tgz",
-      "integrity": "sha512-7IZi8J3Dr9n3tX+lcpmJ/5tCYIqoXdblFBaPuv0SEKZFRpCxE+TqIWL6I3t7jLlk9TWu3JSvEZAhtjB9yvB+zA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
+      "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
       "optional": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-stack": "^3.0.6",
-        "@smithy/protocol-http": "^4.1.3",
-        "@smithy/types": "^3.4.2",
-        "@smithy/util-stream": "^3.1.8",
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1481,9 +1495,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-      "integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1493,13 +1507,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.6.tgz",
-      "integrity": "sha512-47Op/NU8Opt49KyGpHtVdnmmJMsp2hEwBdyjuFB9M2V5QVOwA7pBhhxKN5z6ztKGrMw76gd8MlbPuzzvaAncuQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.8.tgz",
+      "integrity": "sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==",
       "optional": true,
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.6",
-        "@smithy/types": "^3.4.2",
+        "@smithy/querystring-parser": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -1564,14 +1578,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.21.tgz",
-      "integrity": "sha512-M/FhTBk4c/SsB91dD/M4gMGfJO7z/qJaM9+XQQIqBOf4qzZYMExnP7R4VdGwxxH8IKMGW+8F0I4rNtVRrcfPoA==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
+      "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
       "optional": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1580,17 +1594,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.21.tgz",
-      "integrity": "sha512-NiLinPvF86U3S2Pdx/ycqd4bnY5dmFSPNL5KYRwbNjqQFS09M5Wzqk8BNk61/47xCYz1X/6KeiSk9qgYPTtuDw==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
+      "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
       "optional": true,
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.8",
-        "@smithy/credential-provider-imds": "^3.2.3",
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/property-provider": "^3.1.6",
-        "@smithy/smithy-client": "^3.3.5",
-        "@smithy/types": "^3.4.2",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/credential-provider-imds": "^3.2.5",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1598,13 +1612,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.2.tgz",
-      "integrity": "sha512-FEISzffb4H8DLzGq1g4MuDpcv6CIG15fXoQzDH9SjpRJv6h7J++1STFWWinilG0tQh9H1v2UKWG19Jjr2B16zQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.4.tgz",
+      "integrity": "sha512-kPt8j4emm7rdMWQyL0F89o92q10gvCUa6sBkBtDJ7nV2+P7wpXczzOfoDJ49CKXe5CCqb8dc1W+ZdLlrKzSAnQ==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/types": "^3.4.2",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1624,12 +1638,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.6.tgz",
-      "integrity": "sha512-BxbX4aBhI1O9p87/xM+zWy0GzT3CEVcXFPBRDoHAM+pV0eSW156pR+PSYEz0DQHDMYDsYAflC2bQNz2uaDBUZQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
+      "integrity": "sha512-p7iYAPaQjoeM+AKABpYWeDdtwQNxasr4aXQEA/OmbOaug9V0odRVDy3Wx4ci8soljE/JXQo+abV0qZpW8NX0yA==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1637,13 +1651,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.6.tgz",
-      "integrity": "sha512-BRZiuF7IwDntAbevqMco67an0Sr9oLQJqqRCsSPZZHYRnehS0LHDAkJk/pSmI7Z8c/1Vet294H7fY2fWUgB+Rg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
+      "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
       "optional": true,
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.6",
-        "@smithy/types": "^3.4.2",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1651,14 +1665,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.8.tgz",
-      "integrity": "sha512-hoKOqSmb8FD3WLObuB5hwbM7bNIWgcnvkThokTvVq7J5PKjlLUK5qQQcB9zWLHIoSaIlf3VIv2OxZY2wtQjcRQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.2.1.tgz",
+      "integrity": "sha512-R3ufuzJRxSJbE58K9AEnL/uSZyVdHzud9wLS8tIbXclxKzoe09CRohj2xV8wpx5tj7ZbiJaKYcutMm1eYgz/0A==",
       "optional": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.8",
-        "@smithy/node-http-handler": "^3.2.3",
-        "@smithy/types": "^3.4.2",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -1766,17 +1780,17 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.16.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.8.tgz",
-      "integrity": "sha512-sbo5JmfbZNkyDv+2HCccr9Y9ZkKJBMTru7UdAsCojMGjKNjdaOV73bqEW242QrHEZL8R4LbHMrW+FHB5lZ5/bw==",
+      "version": "20.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/node-schedule": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node-schedule/-/node-schedule-2.1.0.tgz",
-      "integrity": "sha512-NiTwl8YN3v/1YCKrDFSmCTkVxFDylueEqsOFdgF+vPsm+AlyJKGAo5yzX1FiOxPsZiN6/r8gJitYx2EaSuBmmg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/node-schedule/-/node-schedule-2.1.7.tgz",
+      "integrity": "sha512-G7Z3R9H7r3TowoH6D2pkzUHPhcJrDF4Jz1JOQ80AX0K2DWTHoN9VC94XzFAPNMdbW9TBzMZ3LjpFi7RYdbxtXA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1792,9 +1806,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.16",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
-      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A=="
+      "version": "6.9.17",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
+      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -1813,13 +1827,14 @@
       }
     },
     "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
+      "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "^2.1.12",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
         "node": ">= 0.12"
@@ -1912,9 +1927,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2749,9 +2764,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3015,9 +3030,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.4.tgz",
+      "integrity": "sha512-HR1gxH5OaiN7XH7uiWH0RLw0RcFySiSoW1ctxmD1ahTw3uGBtkmm/ng0tDU1OtYx5OK6EOL5Y6O21cDflG3Jcg==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -3035,7 +3050,7 @@
         "function.prototype.name": "^1.1.6",
         "get-intrinsic": "^1.2.4",
         "get-symbol-description": "^1.0.2",
-        "globalthis": "^1.0.3",
+        "globalthis": "^1.0.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.0.3",
@@ -3051,10 +3066,10 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.2",
+        "regexp.prototype.flags": "^1.5.3",
         "safe-array-concat": "^1.1.2",
         "safe-regex-test": "^1.0.3",
         "string.prototype.trim": "^1.2.9",
@@ -3211,6 +3226,7 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -3324,9 +3340,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.11.1.tgz",
-      "integrity": "sha512-EwcbfLOhwVMAfatfqLecR2yv3dE5+kQ8kx+Rrt0DvDXEVwW86KQ/xbMDQhtp5l42VXukD5SOF8mQQHbaNtO0CQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7"
@@ -3393,9 +3409,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
-      "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
@@ -3406,7 +3422,7 @@
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.9.0",
+        "eslint-module-utils": "^2.12.0",
         "hasown": "^2.0.2",
         "is-core-module": "^2.15.1",
         "is-glob": "^4.0.3",
@@ -3415,13 +3431,14 @@
         "object.groupby": "^1.0.3",
         "object.values": "^1.2.0",
         "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.8",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -3961,9 +3978,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3994,20 +4011,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5063,9 +5066,9 @@
       }
     },
     "node_modules/logform": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -5539,9 +5542,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
+      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -5647,9 +5650,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.7.2.tgz",
-      "integrity": "sha512-Bq3Ug0SZFtgtL1+0wCnAe8AJtI7yx/00/a2nUug9SkhfOwlKS92Tef12iCK9FdwXw+oFZWMtRnSwcLayQso+xA==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.10.3.tgz",
+      "integrity": "sha512-XL+eX/kyXNoCdtgEFFT26YlGaMq/eUMaxlGWVyR8lqdDvSa9m8rrHRUiR8IYZWwq5B0534E8VXbiSuoUgGGIDw==",
       "dependencies": {
         "@noble/ciphers": "^0.5.1",
         "@noble/curves": "1.2.0",
@@ -5677,9 +5680,9 @@
       "optional": true
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6341,15 +6344,15 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
-        "set-function-name": "^2.0.1"
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7368,9 +7371,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
     },
     "node_modules/tstl": {
@@ -7760,32 +7763,32 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
-      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.1.tgz",
-      "integrity": "sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "dependencies": {
-        "logform": "^2.6.1",
+        "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
   "version": "0.11.1",
   "author": "Francisco Calderón <negrunch@grunch.dev>",
   "description": "P2P lightning network telegram bot",
-  "main": "app.js",
+  "main": "dist/app.js",
   "scripts": {
     "prestart": "npx tsc",
-    "start": "node ./app",
+    "start": "node ./dist/app",
     "predev": "npx tsc",
-    "dev": "nodemon ./app",
+    "dev": "nodemon ./dist/app",
     "lint": "eslint .",
-    "format": "prettier --write '**/*.js'",
-    "pretest": "npx tsc",
-    "test": "export NODE_ENV=test && mocha --exit tests/**/*.spec.js"
+    "format": "prettier --write '**/*.{js,ts}'",
+    "pretest": "tsc -p tsconfig.test.json",
+    "test": "export NODE_ENV=test && mocha --exit 'dist/tests/**/*.spec.js'"
   },
   "license": "MIT",
   "dependencies": {

--- a/tests/bot/bot.spec.ts
+++ b/tests/bot/bot.spec.ts
@@ -198,7 +198,7 @@ describe('Telegram bot', () => {
       flags += flag.length;
     });
     let langs = 0;
-    fs.readdirSync(path.join(__dirname, '../../locales')).forEach(file => {
+    fs.readdirSync(path.join(__dirname, '../../../locales')).forEach(file => {
       langs++;
     });
     expect(flags).to.be.equal(langs);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,23 @@
 {
   "compilerOptions": {
-    "strict": true,
+    "strict": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "downlevelIteration": true
-  }
+    "downlevelIteration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "allowJs": true,
+    "moduleResolution": "node"
+  },
+  "include": [
+    "app.ts",
+    "bot/**/*",
+    "jobs/**/*",
+    "ln/**/*",
+    "lnurl/**/*",
+    "models/**/*",
+    "util/**/*",
+    "locales/**/*",
+  ],
+  "exclude": ["node_modules", "dist", "tests", "locales"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This change avoids having so many untracked JS files generated by the typescript compiler. This project doesn't have a `src` dir and instead all files (.ts and .js) are kept at root. The problem is that for every file that is ported to typescript a new .js file will be generated. But since this is a generated file it shouldn't be tracked by the version control system. On the other hand we cannot also add all .js files to the `.gitignore` file. 