### PR TITLE
bot,util: fix "checkorder" command

### DIFF
--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -670,7 +670,7 @@ const customMessage = async (ctx: MainContext, message: string) => {
   }
 };
 
-const checkOrderMessage = async (ctx: MainContext, order: IOrder, buyer: UserDocument, seller: UserDocument) => {
+const checkOrderMessage = async (ctx: MainContext, order: IOrder, buyer: UserDocument | null, seller: UserDocument | null) => {
   try {
     let message = getDetailedOrder(ctx.i18n, order, buyer, seller);
     message += `\n\n`;

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -532,7 +532,7 @@ const initialize = (botToken: string, options: Partial<Telegraf.Options<MainCont
 
       const buyer = await User.findOne({ _id: order.buyer_id });
       const seller = await User.findOne({ _id: order.seller_id });
-      if (buyer === null || seller === null) throw Error("buyer and/or seller were not found in DB");
+      
       await messages.checkOrderMessage(ctx, order, buyer, seller);
     } catch (error) {
       logger.error(error);

--- a/util/index.ts
+++ b/util/index.ts
@@ -363,7 +363,7 @@ const getUserI18nContext = async (user: UserDocument) => {
   return i18n.createContext(user.lang);
 };
 
-const getDetailedOrder = (i18n: I18nContext, order: IOrder, buyer: UserDocument, seller: UserDocument) => {
+const getDetailedOrder = (i18n: I18nContext, order: IOrder, buyer: UserDocument | null, seller: UserDocument | null) => {
   try {
     const buyerUsername = buyer ? sanitizeMD(buyer.username) : '';
     const buyerReputation = buyer


### PR DESCRIPTION
Don't raise an exception when seller or buyer is null in "checkorder" command code as this is a valid case (an order is in status pending).

Fixes #602 