### PR TITLE
bot, jobs,tests/bot: convert requires to imports

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,11 +1,12 @@
 import "dotenv/config";
 import { SocksProxyAgent } from "socks-proxy-agent";
-import { MainContext, start } from "./bot/start";
+import { start } from "./bot/start";
 import { connect as mongoConnect } from './db_connect'
 const { resubscribeInvoices } = require('./ln');
 import { logger } from "./logger";
 import { Telegraf } from "telegraf";
-const { delay } = require('./util');
+import { delay } from './util';
+import { CommunityContext } from "./bot/modules/community/communityContext";
 
 (async () => {
   process.on('unhandledRejection', e => {
@@ -24,7 +25,7 @@ const { delay } = require('./util');
   mongoose.connection
     .once('open', async () => {
       logger.info('Connected to Mongo instance.');
-      let options: Partial<Telegraf.Options<MainContext>> = { handlerTimeout: 60000 };
+      let options: Partial<Telegraf.Options<CommunityContext>> = { handlerTimeout: 60000 };
       if (process.env.SOCKS_PROXY_HOST) {
         const agent = new SocksProxyAgent(process.env.SOCKS_PROXY_HOST);
         options = {

--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -1,27 +1,26 @@
 import { validateFiatSentOrder, validateReleaseOrder } from './validations';
-const {
+import {
   createHoldInvoice,
   subscribeInvoice,
   cancelHoldInvoice,
   settleHoldInvoice,
-} = require('../ln');
+} from '../ln';
 import { Order, User, Dispute } from '../models';
 import * as messages from './messages';
-import { getBtcFiatPrice, deleteOrderFromChannel, getUserI18nContext, getFee } from '../util';
+import { getBtcFiatPrice, deleteOrderFromChannel, getUserI18nContext, getFee, removeLightningPrefix } from '../util';
 import * as ordersActions from './ordersActions';
-const OrderEvents = require('./modules/events/orders');
-const { removeLightningPrefix } = require('../util');
+import * as OrderEvents from './modules/events/orders';
 
 import { resolvLightningAddress } from '../lnurl/lnurl-pay';
 import { logger } from '../logger';
 import { Telegraf } from 'telegraf';
 import { IOrder } from '../models/order';
 import { UserDocument } from '../models/user';
-import { MainContext } from './start';
+import { HasTelegram, MainContext } from './start';
 import { CommunityContext } from './modules/community/communityContext';
 import { Types } from 'mongoose';
 
-const waitPayment = async (ctx: MainContext, bot: MainContext, buyer: UserDocument, seller: UserDocument, order: IOrder, buyerInvoice: any) => {
+const waitPayment = async (ctx: MainContext, bot: HasTelegram, buyer: UserDocument, seller: UserDocument, order: IOrder, buyerInvoice: any) => {
   try {
     // If there is not fiat amount the function don't do anything
     if (order.fiat_amount === undefined) {
@@ -88,7 +87,7 @@ const waitPayment = async (ctx: MainContext, bot: MainContext, buyer: UserDocume
   }
 };
 
-const addInvoice = async (ctx: CommunityContext, bot: MainContext, order: IOrder | null) => {
+const addInvoice = async (ctx: CommunityContext, bot: HasTelegram, order: IOrder | null = null) => {
   try {
     ctx.deleteMessage();
     ctx.scene.leave();
@@ -177,7 +176,7 @@ const addInvoice = async (ctx: CommunityContext, bot: MainContext, order: IOrder
   }
 };
 
-const rateUser = async (ctx: CommunityContext, bot: MainContext, rating: number, orderId: string) => {
+const rateUser = async (ctx: CommunityContext, bot: HasTelegram, rating: number, orderId: string) => {
   try {
     ctx.deleteMessage();
     ctx.scene.leave();
@@ -240,7 +239,7 @@ const saveUserReview = async (targetUser: UserDocument, rating: number) => {
   }
 };
 
-const cancelAddInvoice = async (ctx: CommunityContext, order: IOrder | null, job?: any) => {
+const cancelAddInvoice = async (ctx: CommunityContext, order: IOrder | null = null, job?: any) => {
   try {
     let userAction = false;
     let userTgId = null;
@@ -357,7 +356,7 @@ const cancelAddInvoice = async (ctx: CommunityContext, order: IOrder | null, job
   }
 };
 
-const showHoldInvoice = async (ctx: CommunityContext, bot: MainContext, order: IOrder | null) => {
+const showHoldInvoice = async (ctx: CommunityContext, bot: HasTelegram, order: IOrder | null = null) => {
   try {
     ctx.deleteMessage();
     if (!order) {
@@ -427,7 +426,7 @@ const showHoldInvoice = async (ctx: CommunityContext, bot: MainContext, order: I
   }
 };
 
-const cancelShowHoldInvoice = async (ctx: CommunityContext, order: IOrder | null, job?: any) => {
+const cancelShowHoldInvoice = async (ctx: CommunityContext, order: IOrder | null = null, job?: any) => {
   try {
     let userAction = false;
     let userTgId = null;
@@ -550,7 +549,7 @@ const cancelShowHoldInvoice = async (ctx: CommunityContext, order: IOrder | null
  * @param {*} order
  * @returns
  */
-const addInvoicePHI = async (ctx: CommunityContext, bot: MainContext, orderId: string) => {
+const addInvoicePHI = async (ctx: CommunityContext, bot: HasTelegram, orderId: string) => {
   try {
     ctx.deleteMessage();
     const order = await Order.findOne({ _id: orderId });
@@ -574,7 +573,7 @@ const addInvoicePHI = async (ctx: CommunityContext, bot: MainContext, orderId: s
   }
 };
 
-const cancelOrder = async (ctx: CommunityContext, orderId: string, user: UserDocument | null) => {
+const cancelOrder = async (ctx: CommunityContext, orderId: string, user: UserDocument | null = null) => {
   try {
     if (user === null) {
       const tgUser = (ctx.update as any).callback_query.from;
@@ -700,7 +699,7 @@ const cancelOrder = async (ctx: CommunityContext, orderId: string, user: UserDoc
   }
 };
 
-const fiatSent = async (ctx: MainContext, orderId: string, user: UserDocument | null) => {
+const fiatSent = async (ctx: MainContext, orderId: string, user: UserDocument | null = null) => {
   try {
     if (!user) {
       const tgUser = (ctx.update as any).callback_query.from;
@@ -736,7 +735,7 @@ const fiatSent = async (ctx: MainContext, orderId: string, user: UserDocument | 
   }
 };
 
-const release = async (ctx: MainContext, orderId: string, user: UserDocument | null) => {
+const release = async (ctx: MainContext, orderId: string, user: UserDocument | null = null) => {
   try {
     if (!user) {
       const tgUser = (ctx.update as any).callback_query.from;

--- a/bot/index.ts
+++ b/bot/index.ts
@@ -1,10 +1,6 @@
-const { initialize, start } = require('./start');
-const {
-  createOrder,
-  getOrder,
-  getNewRangeOrderPayload,
-} = require('./ordersActions');
-const {
+import { initialize, start } from './start';
+import { createOrder, getOrder, getNewRangeOrderPayload } from './ordersActions';
+import {
   validateSellOrder,
   validateBuyOrder,
   validateUser,
@@ -13,8 +9,8 @@ const {
   validateTakeBuyOrder,
   validateReleaseOrder,
   validateDisputeOrder,
-} = require('./validations');
-const {
+} from './validations';
+import {
   startMessage,
   initBotErrorMessage,
   invoicePaymentRequestMessage,
@@ -36,12 +32,11 @@ const {
   onGoingTakeBuyMessage,
   pendingSellMessage,
   pendingBuyMessage,
-  beginDisputeMessage,
   notOrderMessage,
   customMessage,
-} = require('./messages');
+} from './messages';
 
-module.exports = {
+export {
   initialize,
   start,
   createOrder,
@@ -75,7 +70,6 @@ module.exports = {
   onGoingTakeBuyMessage,
   pendingSellMessage,
   pendingBuyMessage,
-  beginDisputeMessage,
   notOrderMessage,
   customMessage,
   getNewRangeOrderPayload,

--- a/bot/middleware/stage.ts
+++ b/bot/middleware/stage.ts
@@ -1,14 +1,10 @@
 // @ts-check
 import { Scenes } from 'telegraf';
 import * as CommunityModule from '../modules/community';
-const OrdersModule = require('../modules/orders');
+import * as OrdersModule from '../modules/orders';
 import * as UserModule from '../modules/user';
 import { CommunityContext } from '../modules/community/communityContext';
-const {
-  addInvoiceWizard,
-  addFiatAmountWizard,
-  addInvoicePHIWizard,
-} = require('../scenes');
+import { addInvoiceWizard, addFiatAmountWizard, addInvoicePHIWizard } from '../scenes';
 
 export const stageMiddleware = () => {
   const scenes = [

--- a/bot/middleware/stage.ts
+++ b/bot/middleware/stage.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { Scenes } from 'telegraf';
 import * as CommunityModule from '../modules/community';
 import * as OrdersModule from '../modules/orders';

--- a/bot/middleware/user.ts
+++ b/bot/middleware/user.ts
@@ -1,8 +1,8 @@
-import { MainContext } from "../start";
+import { CommunityContext } from "../modules/community/communityContext";
 
 import { validateUser, validateAdmin, validateSuperAdmin } from '../validations';
 
-export const userMiddleware = async (ctx: MainContext, next: () => void) => {
+export const userMiddleware = async (ctx: CommunityContext, next: () => void) => {
   const user = await validateUser(ctx, false);
   if (!user) return false;
   ctx.i18n.locale(user.lang);
@@ -11,7 +11,7 @@ export const userMiddleware = async (ctx: MainContext, next: () => void) => {
   next();
 };
 
-export const adminMiddleware = async (ctx: MainContext, next: () => void) => {
+export const adminMiddleware = async (ctx: CommunityContext, next: () => void) => {
   const admin = await validateAdmin(ctx);
   if (!admin) return false;
   ctx.i18n.locale(admin.lang);
@@ -20,7 +20,7 @@ export const adminMiddleware = async (ctx: MainContext, next: () => void) => {
   next();
 };
 
-export const superAdminMiddleware = async (ctx: MainContext, next: () => void) => {
+export const superAdminMiddleware = async (ctx: CommunityContext, next: () => void) => {
   const admin = await validateSuperAdmin(ctx);
   if (!admin) return false;
   ctx.i18n.locale(admin.lang);

--- a/bot/modules/community/commands.ts
+++ b/bot/modules/community/commands.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-// @ts-check
 import { logger } from '../../../logger';
 import { showUserCommunitiesMessage } from './messages';
 import { Community, Order } from '../../../models';

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { Telegraf } from 'telegraf';
 import { userMiddleware } from '../../middleware/user';
 import * as actions from './actions';

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -1,6 +1,6 @@
 // @ts-check
 import { Telegraf } from 'telegraf';
-const { userMiddleware } = require('../../middleware/user');
+import { userMiddleware } from '../../middleware/user';
 import * as actions from './actions';
 import * as commands from './commands';
 import { earningsMessage, updateCommunityMessage, sureMessage } from './messages';

--- a/bot/modules/community/scenes.communityAdmin.ts
+++ b/bot/modules/community/scenes.communityAdmin.ts
@@ -1,7 +1,7 @@
 import { Scenes } from 'telegraf';
 import { CommunityContext } from './communityContext';
 
-const CommunityEvents = require('../events/community');
+import * as CommunityEvents from '../events/community';
 
 const communityAdmin = () => {
   const scene = new Scenes.WizardScene('COMMUNITY_ADMIN', async (ctx: CommunityContext) => {

--- a/bot/modules/community/scenes.ts
+++ b/bot/modules/community/scenes.ts
@@ -2,7 +2,7 @@ import { Scenes } from 'telegraf';
 import { logger } from '../../../logger';
 import { Community, User, PendingPayment } from '../../../models';
 import { IOrderChannel, IUsernameId } from '../../../models/community';
-const { isPendingPayment } = require('../../../ln');
+import { isPendingPayment } from '../../../ln';
 import { isGroupAdmin, itemsFromMessage, removeAtSymbol } from '../../../util';
 import * as messages from '../../messages';
 import { isValidInvoice } from '../../validations';

--- a/bot/modules/dispute/actions.ts
+++ b/bot/modules/dispute/actions.ts
@@ -2,7 +2,7 @@ import { User, Order, Dispute } from '../../../models';
 import { MainContext } from '../../start';
 import * as messages from './messages';
 import { validateAdmin } from '../../validations';
-const globalMessages = require('../../messages');
+import * as globalMessages from '../../messages';
 
 export const takeDispute = async (ctx: MainContext) : Promise<void> => {
   const tgId: string = (ctx.update as any).callback_query.from.id;

--- a/bot/modules/dispute/commands.ts
+++ b/bot/modules/dispute/commands.ts
@@ -3,8 +3,9 @@ import { MainContext } from "../../start";
 import { User, Dispute, Order } from '../../../models';
 import { validateParams, validateObjectId, validateDisputeOrder } from '../../validations';
 import * as messages from './messages';
-const globalMessages = require('../../messages');
+import * as globalMessages from '../../messages';
 import { logger } from '../../../logger';
+import * as OrderEvents from '../../modules/events/orders';
 import { removeAtSymbol } from '../../../util';
 
 const dispute = async (ctx: MainContext) => {

--- a/bot/modules/dispute/index.ts
+++ b/bot/modules/dispute/index.ts
@@ -1,10 +1,10 @@
 import * as commands from './commands';
 import * as actions from './actions';
 import { Telegraf } from 'telegraf';
-import { MainContext } from '../../start';
-const { userMiddleware, adminMiddleware } = require('../../middleware/user');
+import { userMiddleware, adminMiddleware } from '../../middleware/user';
+import { CommunityContext } from '../community/communityContext';
 
-export const configure = (bot: Telegraf<MainContext>) => {
+export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('dispute', userMiddleware, commands.dispute);
   bot.command('deldispute', adminMiddleware, commands.deleteDispute);
   bot.action(

--- a/bot/modules/events/community.ts
+++ b/bot/modules/events/community.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { ICommunity } from '../../../models/community';
 import * as Events from './index';
 import { TYPES as ORDER_TYPES } from './orders';

--- a/bot/modules/events/orders.ts
+++ b/bot/modules/events/orders.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { IOrder } from '../../../models/order';
 import * as Events from './index';
 

--- a/bot/modules/language/index.ts
+++ b/bot/modules/language/index.ts
@@ -1,10 +1,11 @@
-const { userMiddleware } = require('../../middleware/user');
+import { userMiddleware } from '../../middleware/user';
 import * as commands from './commands';
 import * as actions from './actions';
 import { Telegraf } from 'telegraf';
 import { MainContext } from '../../start';
+import { CommunityContext } from '../community/communityContext';
 
-exports.configure = (bot: Telegraf) => {
+export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('setlang', userMiddleware, ctx => commands.setlang(ctx as unknown as MainContext));
   bot.action(/^setLanguage_([a-z]{2})$/, userMiddleware, ctx => actions.setLanguage(ctx as unknown as MainContext));
 };

--- a/bot/modules/nostr/index.ts
+++ b/bot/modules/nostr/index.ts
@@ -4,11 +4,11 @@ import * as Config from './config';
 import { createOrderEvent } from './events';
 import * as Commands from './commands';
 import { Telegraf } from 'telegraf';
-import { MainContext } from '../../start';
 import { IOrder } from '../../../models/order';
-const CommunityEvents = require('../events/community');
+import * as CommunityEvents from '../events/community';
+import { CommunityContext } from '../community/communityContext';
 
-export const configure = (bot: Telegraf<MainContext>) => {
+export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('/nostr', Commands.info);
 
   if (!Config.getRelays().length) {

--- a/bot/modules/orders/commands.ts
+++ b/bot/modules/orders/commands.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { logger } from '../../../logger';
 import { Community, Order } from '../../../models';
 import { isFloat } from '../../../util';

--- a/bot/modules/orders/index.ts
+++ b/bot/modules/orders/index.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { userMiddleware } from '../../middleware/user';
 import { logger } from '../../../logger';
 import * as ordersActions from '../../ordersActions';

--- a/bot/modules/orders/index.ts
+++ b/bot/modules/orders/index.ts
@@ -10,6 +10,7 @@ import { takeOrderActionValidation, takeOrderValidation, takesell, takebuyValida
 import { extractId } from '../../../util';
 import { Telegraf } from 'telegraf';
 import { CommunityContext } from '../community/communityContext';
+import { MainContext } from '../../start';
 export * as Scenes from './scenes';
 
 export const configure = (bot: Telegraf<CommunityContext>) => {

--- a/bot/modules/orders/takeOrder.ts
+++ b/bot/modules/orders/takeOrder.ts
@@ -6,7 +6,7 @@ import { deleteOrderFromChannel } from '../../../util';
 import * as messages from '../../messages';
 import { HasTelegram, MainContext } from '../../start';
 import { validateUserWaitingOrder, isBannedFromCommunity, validateTakeSellOrder, validateSeller, validateObjectId, validateTakeBuyOrder } from '../../validations';
-const OrderEvents = require('../../modules/events/orders');
+import * as OrderEvents from '../../modules/events/orders';
 
 export const takeOrderActionValidation = async (ctx: MainContext, next: () => void) => {
   try {

--- a/bot/modules/orders/takeOrder.ts
+++ b/bot/modules/orders/takeOrder.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { Telegraf } from 'telegraf';
 import { logger } from '../../../logger';
 import { Order } from '../../../models';

--- a/bot/modules/user/index.ts
+++ b/bot/modules/user/index.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { userMiddleware } from '../../middleware/user';
 
 import { Telegraf } from 'telegraf';

--- a/bot/modules/user/index.ts
+++ b/bot/modules/user/index.ts
@@ -1,5 +1,5 @@
 // @ts-check
-const { userMiddleware } = require('../../middleware/user');
+import { userMiddleware } from '../../middleware/user';
 
 import { Telegraf } from 'telegraf';
 import Scenes from './scenes';

--- a/bot/ordersActions.ts
+++ b/bot/ordersActions.ts
@@ -9,7 +9,7 @@ import { MainContext } from './start';
 import { IOrder } from '../models/order';
 import { IFiat } from '../util/fiatModel';
 
-const OrderEvents = require('./modules/events/orders');
+import * as OrderEvents from './modules/events/orders';
 
 interface CreateOrderArguments {
   type: string;

--- a/bot/scenes.ts
+++ b/bot/scenes.ts
@@ -1,15 +1,15 @@
 import { Scenes } from 'telegraf';
-const { parsePaymentRequest } = require('invoices');
+import { parsePaymentRequest } from 'invoices';
 import { isValidInvoice, validateLightningAddress } from './validations';
 import { Order, PendingPayment } from '../models';
 import { waitPayment, addInvoice, showHoldInvoice } from './commands';
 import { getCurrency, getUserI18nContext } from '../util';
 import * as messages from './messages';
-const { isPendingPayment } = require('../ln');
+import { isPendingPayment } from '../ln';
 import { logger } from '../logger';
 import { resolvLightningAddress } from '../lnurl/lnurl-pay';
 import { CommunityContext } from './modules/community/communityContext';
-const OrderEvents = require('./modules/events/orders');
+import * as OrderEvents from './modules/events/orders';
 
 interface InvoiceParseResult { 
   invoice?: any;

--- a/bot/validations.ts
+++ b/bot/validations.ts
@@ -5,12 +5,12 @@ import { UserDocument } from "../models/user";
 import { IOrder } from "../models/order";
 import { Telegraf } from "telegraf";
 
-const { parsePaymentRequest } = require('invoices');
+import { parsePaymentRequest } from 'invoices';
 const { ObjectId } = require('mongoose').Types;
 import * as messages from './messages';
 import { Order, User, Community } from '../models';
 import { isIso4217, isDisputeSolver, removeLightningPrefix, isOrderCreator } from '../util';
-const { existLightningAddress } = require('../lnurl/lnurl-pay');
+import { existLightningAddress } from '../lnurl/lnurl-pay';
 import { logger } from '../logger';
 
 const ctxUpdateMessageFromAssertMsg = "ctx.update.message.from is not available";

--- a/jobs/cancel_orders.ts
+++ b/jobs/cancel_orders.ts
@@ -1,13 +1,14 @@
 import { Telegraf } from "telegraf";
-import { MainContext } from "../bot/start";
+import { HasTelegram, MainContext } from "../bot/start";
 import { User, Order } from "../models";
-const { cancelShowHoldInvoice, cancelAddInvoice } = require('../bot/commands');
+import { cancelShowHoldInvoice, cancelAddInvoice } from '../bot/commands';
 import * as messages from "../bot/messages";
 import { getUserI18nContext, holdInvoiceExpirationInSecs } from '../util';
 import { logger } from "../logger";
-const OrderEvents = require('../bot/modules/events/orders');
+import { CommunityContext } from "../bot/modules/community/communityContext";
+import * as OrderEvents from '../bot/modules/events/orders';
 
-const cancelOrders = async (bot: Telegraf<MainContext>) => {
+const cancelOrders = async (bot: HasTelegram) => {
   try {
     const holdInvoiceTime = new Date();
     holdInvoiceTime.setSeconds(
@@ -30,9 +31,9 @@ const cancelOrders = async (bot: Telegraf<MainContext>) => {
     });
     for (const order of waitingPaymentOrders) {
       if (order.status === 'WAITING_PAYMENT') {
-        await cancelShowHoldInvoice(bot, order, true);
+        await cancelShowHoldInvoice(bot as CommunityContext, order, true);
       } else {
-        await cancelAddInvoice(bot, order, true);
+        await cancelAddInvoice(bot as CommunityContext, order, true);
       }
     }
     // We get the expired order where the seller sent the sats but never released the order

--- a/jobs/communities.ts
+++ b/jobs/communities.ts
@@ -1,10 +1,10 @@
 import { Telegraf } from "telegraf";
-import { MainContext } from "../bot/start";
 
 import { Order, Community } from '../models';
 import { logger } from "../logger";
+import { CommunityContext } from "../bot/modules/community/communityContext";
 
-const deleteCommunity = async (bot: Telegraf<MainContext>) => {
+const deleteCommunity = async (bot: Telegraf<CommunityContext>) => {
   try {
     const communities = await Community.find();
     for (const community of communities) {

--- a/jobs/delete_published_orders.ts
+++ b/jobs/delete_published_orders.ts
@@ -1,11 +1,12 @@
 import { Telegraf } from "telegraf";
-import { MainContext } from "../bot/start";
 
 import { Order } from '../models';
-const { deleteOrderFromChannel } = require('../util');
+import { deleteOrderFromChannel } from '../util';
 import { logger } from '../logger';
+import { CommunityContext } from "../bot/modules/community/communityContext";
+import { IOrder } from "../models/order";
 
-const deleteOrders = async (bot: Telegraf<MainContext>) => {
+const deleteOrders = async (bot: Telegraf<CommunityContext>) => {
   try {
     const windowTime = new Date();
     windowTime.setSeconds(
@@ -21,7 +22,7 @@ const deleteOrders = async (bot: Telegraf<MainContext>) => {
       logger.info(
         `Pending order Id: ${order._id} expired after ${process.env.ORDER_PUBLISHED_EXPIRATION_WINDOW} seconds, deleting it from database and channel`
       );
-      const orderCloned = order.toObject();
+      const orderCloned = order.toObject() as IOrder;
       // We remove the order from the database first, then we remove the message from the channel
       await order.remove();
       // We delete the messages related to that order from the channel

--- a/jobs/node_info.ts
+++ b/jobs/node_info.ts
@@ -1,11 +1,11 @@
 import { Telegraf } from "telegraf";
-import { MainContext } from "../bot/start";
 
 import { Config } from '../models';
+import { CommunityContext } from "../bot/modules/community/communityContext";
 const { getInfo } = require('../ln');
-const { logger } = require('../logger');
+import { logger } from '../logger';
 
-const info = async (bot: Telegraf<MainContext>) => {
+const info = async (bot: Telegraf<CommunityContext>) => {
   try {
     let config = await Config.findOne({});
     if (config === null) {

--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -4,11 +4,12 @@ import { logger } from "../logger";
 import { Telegraf } from 'telegraf';
 import { I18nContext } from '@grammyjs/i18n';
 import { MainContext } from '../bot/start';
-const { payRequest, isPendingPayment } = require('../ln');
+import { payRequest, isPendingPayment } from '../ln';
 import { getUserI18nContext } from '../util';
-const { orderUpdated } = require('../bot/modules/events/orders');
+import { CommunityContext } from '../bot/modules/community/communityContext';
+import { orderUpdated } from '../bot/modules/events/orders';
 
-export const attemptPendingPayments = async (bot: Telegraf<MainContext>): Promise<void> => {
+export const attemptPendingPayments = async (bot: Telegraf<CommunityContext>): Promise<void> => {
   const pendingPayments = await PendingPayment.find({
     paid: false,
     attempts: { $lt: process.env.PAYMENT_ATTEMPTS },
@@ -118,7 +119,7 @@ export const attemptPendingPayments = async (bot: Telegraf<MainContext>): Promis
   }
 };
 
-export const attemptCommunitiesPendingPayments = async (bot: Telegraf<MainContext>): Promise<void> => {
+export const attemptCommunitiesPendingPayments = async (bot: Telegraf<CommunityContext>): Promise<void> => {
   const pendingPayments = await PendingPayment.find({
     paid: false,
     attempts: { $lt: process.env.PAYMENT_ATTEMPTS },

--- a/tests/bot/bot.spec.ts
+++ b/tests/bot/bot.spec.ts
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const { expect } = require('chai');
 const proxyquire = require('proxyquire');
 
-const { initialize } = require('../../bot');
+import { initialize } from '../../bot';
 import { User, Order } from '../../models';
 import { getCurrenciesWithPrice } from '../../util';
 import { mockUpdatesResponseForCurrencies } from './mocks/currenciesResponse';


### PR DESCRIPTION
Converted requires to imports where applicable and fixed
type errors resulting from it.

Also removed `@ts-check` annotations. They are used to typecheck .js files, but make no sense in .ts files as they are already type-checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the bot’s internal architecture by standardizing module imports and refining context handling for community interactions.
	- Improved error handling and type safety across commands, messaging, and payment processing, leading to more consistent and reliable operations.

- **Chore**
	- Streamlined code structure and updated module syntax to boost maintainability and performance.
	- Transitioned from CommonJS to ES module syntax for imports across multiple files, enhancing consistency and modernizing the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->