### PR TITLE
bot: check for any falsey value of user in cancelOrder

### DIFF
--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -575,14 +575,14 @@ const addInvoicePHI = async (ctx: CommunityContext, bot: HasTelegram, orderId: s
 
 const cancelOrder = async (ctx: CommunityContext, orderId: string, user: UserDocument | null = null) => {
   try {
-    if (user === null) {
+    if (!user) {
       const tgUser = (ctx.update as any).callback_query.from;
       if (!tgUser) return;
 
       user = await User.findOne({ tg_id: tgUser.id });
 
       // If user didn't initialize the bot we can't do anything
-      if (user == null) return;
+      if (!user) return;
     }
     if (user.banned) return await messages.bannedUserErrorMessage(ctx, user);
     const order = await ordersActions.getOrder(ctx, user, orderId);


### PR DESCRIPTION
Despite `user` having type `UserDocument | null`, there was case [1] of it being `undefined`, leading to error when reading `banned` property after merging [2]. So go back to using `!user` checks that also account for `undefined`, so function will exit early and not produce an error.

[1] https://github.com/lnp2pBot/bot/pull/633#issuecomment-2807056971
[2] https://github.com/lnp2pBot/bot/pull/633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code readability by simplifying user checks when handling order cancellations. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->