### PR TITLE
Fix order link in nostr events

### DIFF
--- a/bot/modules/nostr/events.ts
+++ b/bot/modules/nostr/events.ts
@@ -40,8 +40,18 @@ const orderToTags = async (order: IOrder) => {
     const community = await Community.findById(order.community_id);
     if(community === null)
       throw new Error("community was not found");
-    const group = removeAtSymbol(community.group);
-    source = `https://t.me/${group}/${order.tg_channel_message1}`;
+    let order_channel: string;    
+    if (community.order_channels.length === 1)
+      order_channel = removeAtSymbol(community.order_channels[0].name);
+    else if (community.order_channels.length === 2){
+      if (order.type == 'buy'){
+        order_channel = removeAtSymbol(community.order_channels[0].name);
+      }
+      else {
+        order_channel = removeAtSymbol(community.order_channels[1].name);
+      }     
+    }    
+    source = `https://t.me/${order_channel}/${order.tg_channel_message1}`;
     tags.push(['community_id', order.community_id]);
   }
   tags.push(['source', source]);

--- a/bot/modules/nostr/events.ts
+++ b/bot/modules/nostr/events.ts
@@ -44,7 +44,7 @@ const orderToTags = async (order: IOrder) => {
     if (community.order_channels.length === 1)
       order_channel = removeAtSymbol(community.order_channels[0].name);
     else if (community.order_channels.length === 2){
-      if (order.type == 'buy'){
+      if (order.type === 'buy'){
         order_channel = removeAtSymbol(community.order_channels[0].name);
       }
       else {


### PR DESCRIPTION
fix #649 
Ahora el link de la orden se muestra correctamente en los eventos 38383 publicados en nostr. Se muestra en el canal donde la orden fue publicada: en el canal general, en el de la comunidad, o si la comunidad tiene un canal para ventas y otro para compras.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved selection of the Telegram channel in the order event source URL, ensuring the correct channel is displayed based on the order type and community configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->