### PR TITLE
Replace markdownV2 in some messages

### DIFF
--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -54,7 +54,7 @@ const waitPayment = async (ctx: MainContext, bot: HasTelegram, buyer: UserDocume
         fiatAmount: order.fiat_amount,
       });
       const amount = Math.floor(order.amount + order.fee);
-      const { _request, hash, secret } = await createHoldInvoice({
+      const { hash, secret } = await createHoldInvoice({
         amount,
         description,
       });

--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -76,8 +76,7 @@ const invoicePaymentRequestMessage = async (
     // We need the buyer rating
     const stars = getEmojiRate(buyer.total_rating);
     const roundedRating = decimalRound(buyer.total_rating, -1);
-    let rate = `${roundedRating} ${stars} (${buyer.total_reviews})`;
-    rate = sanitizeMD(rate);
+    const rate = `${roundedRating} ${stars} (${buyer.total_reviews})`;
     // Extracting the buyer's days in the platform
     const ageInDays = getUserAge(buyer);
 
@@ -89,7 +88,7 @@ const invoicePaymentRequestMessage = async (
       days: ageInDays,
     });
 
-    await ctx.telegram.sendMessage(user.tg_id, message, { parse_mode: 'MarkdownV2' });
+    await ctx.telegram.sendMessage(user.tg_id, message, { parse_mode: 'Markdown' });
 
     await ctx.telegram.sendMessage(user.tg_id, order._id, {
       reply_markup: {
@@ -125,7 +124,7 @@ const showQRCodeMessage = async (
         type: 'photo',
         media: { source: qrBytes },
         caption: ['`', request, '`'].join(''),
-        parse_mode: 'MarkdownV2',
+        parse_mode: 'Markdown',
       },
     ]);
   } catch (error) {
@@ -154,7 +153,7 @@ const pendingSellMessage = async (ctx: MainContext, user: UserDocument, order: I
     await ctx.telegram.sendMessage(
       user.tg_id,
       i18n.t('cancel_order_cmd', { orderId: order._id }),
-      { parse_mode: 'MarkdownV2' }
+      { parse_mode: 'Markdown' }
     );
     
     if (order.is_golden_honey_badger === true && order.type === 'sell') {


### PR DESCRIPTION
Most of the times MDV2 is unnecessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved message formatting by switching from 'MarkdownV2' to 'Markdown' in multiple Telegram messages for simpler and more consistent display.
  - Removed unnecessary sanitization of the buyer rating in invoice payment request messages.

- **Refactor**
  - Streamlined internal handling of hold invoice creation responses for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->