### PR TITLE
Add commit hash to /version command

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -82,6 +82,8 @@ RELAYS='ws://localhost:7000,ws://localhost:8000,ws://localhost:9000'
 # Seconds to wait to allow disputes to be started
 DISPUTE_START_WINDOW=600
 
+#The relative size of the random image when compared to the qr (as a ratio of imageWidth/qrWidth)
+IMAGE_TO_QR_RATIO=0.2
 
 # Probability of golden honey badger appearance (1 in X orders)
 GOLDEN_HONEY_BADGER_PROBABILITY=100

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -259,8 +259,13 @@ const initialize = (botToken: string, options: Partial<Telegraf.Options<Communit
   bot.command('version', async (ctx: MainContext) => {
     try {
       const pckg = require('../../package.json');
-      const commitHash =  execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-      await ctx.reply(pckg.version + '\n' + commitHash);
+      let commitHash = 'unknown';
+      try {
+        commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+      } catch (error) {
+        logger.warn(`Could not retrieve Git commit hash: ${error.message}`);
+      }
+      await ctx.reply(`${pckg.version}\n${commitHash}`);
     } catch (err) {
       logger.error(err);
     }

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { Telegraf, session, Context, Telegram } from 'telegraf';
 import { I18n, I18nContext } from '@grammyjs/i18n';
 import { Message } from 'typegram'
@@ -258,7 +259,8 @@ const initialize = (botToken: string, options: Partial<Telegraf.Options<Communit
   bot.command('version', async (ctx: MainContext) => {
     try {
       const pckg = require('../../package.json');
-      await ctx.reply(pckg.version);
+      const commitHash =  execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+      await ctx.reply(pckg.version + '\n' + commitHash);
     } catch (err) {
       logger.error(err);
     }

--- a/util/index.ts
+++ b/util/index.ts
@@ -14,8 +14,8 @@ const fs = require('fs').promises;
 const path = require('path');
 const { I18n } = require('@grammyjs/i18n');
 
-const QRCode = require('qrcode');
-const { Image, createCanvas } = require('canvas');
+import QRCode from "qrcode";
+import { Image, createCanvas } from 'canvas';
 // ISO 639-1 language codes
 
 const languages: ILanguages = languagesJson;
@@ -619,7 +619,8 @@ const generateQRWithImage = async (request, randomImage) => {
   const centerImage = new Image();
   centerImage.src = `data:image/png;base64,${randomImage}`;
 
-  const imageSize = canvas.width * 0.3;
+  const imageToQrRatio = parseFloat(process.env.IMAGE_TO_QR_RATIO?? '0.2')
+  const imageSize = canvas.width * imageToQrRatio;
   const imagePos = (canvas.width - imageSize) / 2;
 
   ctx.drawImage(centerImage, imagePos, imagePos, imageSize, imageSize);

--- a/util/index.ts
+++ b/util/index.ts
@@ -619,7 +619,7 @@ const generateQRWithImage = async (request, randomImage) => {
   const centerImage = new Image();
   centerImage.src = `data:image/png;base64,${randomImage}`;
 
-  const imageToQrRatio = parseFloat(process.env.IMAGE_TO_QR_RATIO?? '0.2')
+  const imageToQrRatio = parseFloat(process.env.IMAGE_TO_QR_RATIO?? '0.2');
   const imageSize = canvas.width * imageToQrRatio;
   const imagePos = (canvas.width - imageSize) / 2;
 


### PR DESCRIPTION
I added the hash of the last commit when you run the /version command.
The output of the version command now looks as follows:
/version
0.12.4
2bbf06574b2bc2221c9605ca6b0ca5108f265f78

Fix #654 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - The /version command now displays both the app version and the current Git commit hash.
  - Added support for configuring the size ratio of images embedded within QR codes via a new environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->