### PR TITLE
Add commit hash to /version command #658

### DIFF
--- a/bot/start.ts
+++ b/bot/start.ts
@@ -259,8 +259,13 @@ const initialize = (botToken: string, options: Partial<Telegraf.Options<Communit
   bot.command('version', async (ctx: MainContext) => {
     try {
       const pckg = require('../../package.json');
-      const commitHash =  execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-      await ctx.reply(pckg.version + '\n' + commitHash);
+      let commitHash = 'unknown';
+      try {
+        commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+      } catch (error) {
+        logger.warn(`Could not retrieve Git commit hash: ${error.message}`);
+      }
+      await ctx.reply(`${pckg.version}\n${commitHash}`);
     } catch (err) {
       logger.error(err);
     }


### PR DESCRIPTION
The program now checks the hash of the last commit every time /version command is prompted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The bot's version command now displays both the package version and the current Git commit hash. If the commit hash cannot be retrieved, it will show as 'unknown'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->