### PR TITLE
Reduce the size of the images within the QR of the invoice #641

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -82,10 +82,11 @@ RELAYS='ws://localhost:7000,ws://localhost:8000,ws://localhost:9000'
 # Seconds to wait to allow disputes to be started
 DISPUTE_START_WINDOW=600
 
+#The relative size of the random image when compared to the qr (as a ratio of imageWidth/qrWidth)
+IMAGE_TO_QR_RATIO=0.2
 
 # Probability of golden honey badger appearance (1 in X orders)
 GOLDEN_HONEY_BADGER_PROBABILITY=100
 
 # Number of notification messages sent to the admin, informing them of lack of solvers before disabling the community. The admin receives `MAX_ADMIN_WARNINGS_BEFORE_DEACTIVATION - 1` notification messages.
 MAX_ADMIN_WARNINGS_BEFORE_DEACTIVATION=10
-

--- a/util/index.ts
+++ b/util/index.ts
@@ -10,12 +10,12 @@ import fiatJson from './fiat.json';
 import languagesJson from './languages.json';
 import { Order, Community } from "../models";
 import { logger } from "../logger";
-const fs = require('fs').promises;
+import QRCode from "qrcode";
+import { Image, createCanvas } from 'canvas';const fs = require('fs').promises;
+
 const path = require('path');
 const { I18n } = require('@grammyjs/i18n');
 
-import QRCode from "qrcode";
-import { Image, createCanvas } from 'canvas';
 // ISO 639-1 language codes
 
 const languages: ILanguages = languagesJson;

--- a/util/index.ts
+++ b/util/index.ts
@@ -624,7 +624,7 @@ const generateQRWithImage = async (request, randomImage) => {
   
   // Validate ratio is a valid number between 0.1 and 0.5
   if (isNaN(imageToQrRatio) || imageToQrRatio < 0.1 || imageToQrRatio > 0.5) {
-    logger.warn(`Invalid IMAGE_TO_QR_RATIO value: ${rawRatio}, using default 0.2`);
+    logger.warning(`Invalid IMAGE_TO_QR_RATIO value: ${rawRatio}, using default 0.2`);
     imageToQrRatio = 0.2;
   }
   

--- a/util/index.ts
+++ b/util/index.ts
@@ -619,7 +619,15 @@ const generateQRWithImage = async (request, randomImage) => {
   const centerImage = new Image();
   centerImage.src = `data:image/png;base64,${randomImage}`;
 
-  const imageToQrRatio = parseFloat(process.env.IMAGE_TO_QR_RATIO?? '0.2');
+  const rawRatio = process.env.IMAGE_TO_QR_RATIO ?? '0.2';
+  let imageToQrRatio = parseFloat(rawRatio);
+  
+  // Validate ratio is a valid number between 0.1 and 0.5
+  if (isNaN(imageToQrRatio) || imageToQrRatio < 0.1 || imageToQrRatio > 0.5) {
+    logger.warn(`Invalid IMAGE_TO_QR_RATIO value: ${rawRatio}, using default 0.2`);
+    imageToQrRatio = 0.2;
+  }
+  
   const imageSize = canvas.width * imageToQrRatio;
   const imagePos = (canvas.width - imageSize) / 2;
 

--- a/util/index.ts
+++ b/util/index.ts
@@ -14,8 +14,8 @@ const fs = require('fs').promises;
 const path = require('path');
 const { I18n } = require('@grammyjs/i18n');
 
-const QRCode = require('qrcode');
-const { Image, createCanvas } = require('canvas');
+import QRCode from "qrcode";
+import { Image, createCanvas } from 'canvas';
 // ISO 639-1 language codes
 
 const languages: ILanguages = languagesJson;
@@ -619,7 +619,8 @@ const generateQRWithImage = async (request, randomImage) => {
   const centerImage = new Image();
   centerImage.src = `data:image/png;base64,${randomImage}`;
 
-  const imageSize = canvas.width * 0.3;
+  const imageToQrRatio = parseFloat(process.env.IMAGE_TO_QR_RATIO?? '0.2');
+  const imageSize = canvas.width * imageToQrRatio;
   const imagePos = (canvas.width - imageSize) / 2;
 
   ctx.drawImage(centerImage, imagePos, imagePos, imageSize, imageSize);

--- a/util/index.ts
+++ b/util/index.ts
@@ -11,8 +11,9 @@ import languagesJson from './languages.json';
 import { Order, Community } from "../models";
 import { logger } from "../logger";
 import QRCode from "qrcode";
-import { Image, createCanvas } from 'canvas';const fs = require('fs').promises;
+import { Image, createCanvas } from 'canvas';
 
+const fs = require('fs').promises;
 const path = require('path');
 const { I18n } = require('@grammyjs/i18n');
 


### PR DESCRIPTION
To reduce the size of the images I added a new configuration environment variable that can set the size of an image relative to the size of the qr image, for instance if IMAGE_TO_QR_RATIO is set to 0.2 that means that imageWidth = 0.2*qrWidth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the size ratio of the center image relative to the QR code using a new environment variable.

- **Chores**
  - Updated sample environment file to include the new configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->