### PR TITLE
Fix rating formula

### DIFF
--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -220,11 +220,6 @@ const saveUserReview = async (targetUser: UserDocument, rating: number) => {
     totalReviews++;
 
     const oldRating = targetUser.total_rating;
-    let lastRating = targetUser.reviews.length
-      ? targetUser.reviews[targetUser.reviews.length - 1].rating
-      : 0;
-
-    lastRating = targetUser.last_rating ? targetUser.last_rating : lastRating;
 
     // newRating is an average of all the ratings given to the user.
     // Its formula is based on the iterative method to compute mean,

--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -230,7 +230,7 @@ const saveUserReview = async (targetUser: UserDocument, rating: number) => {
     // Its formula is based on the iterative method to compute mean,
     // as in:
     // https://math.stackexchange.com/questions/2148877/iterative-calculation-of-mean-and-standard-deviation
-    const newRating = oldRating + (lastRating - oldRating) / totalReviews;
+    const newRating = oldRating + (rating - oldRating) / totalReviews;
     targetUser.total_rating = newRating;
     targetUser.last_rating = rating;
     targetUser.total_reviews = totalReviews;


### PR DESCRIPTION
This PR only changes 1 line of code but fixes a problem that has been affecting every user.

I noticed that this formula is slightly incorrect. The first review will always be 0 (which is invalid) and the current rating will always the applies to the next time the bot asks for a review.

The main problem here is that every user will start with a low rating, even when they did everything right.

1. The first time the user gets a 5 star rating, it will still be 0 so it won't appear on the offer.

2. The second time, it will be (0+5)/2 = 2.5

![2](https://github.com/user-attachments/assets/9a6f8046-c43e-4eeb-a15a-8c9cc9189562)

3. The third time time, it will be (0+5+5)/3 = 3.3

![3](https://github.com/user-attachments/assets/9646597d-0a93-4ec3-a6f0-cbd1c43ee451)

I'm not sure if there's a way to fix the existing users, as apparently the review history is not stored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the calculation of a user's average rating to accurately reflect the latest submitted review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->