### PR TITLE
Fix typo IRT translation from "ریال" to "تومان"

### DIFF
--- a/util/fiat.json
+++ b/util/fiat.json
@@ -594,13 +594,13 @@
   },
   "IRT": {
     "symbol": "IRT",
-    "name": "Iranian Tomen",
+    "name": "Iranian Toman",
     "symbol_native": "تومان",
     "decimal_digits": 0,
     "rounding": 0,
     "code": "IRT",
     "emoji": "🇮🇷",
-    "name_plural": "Iranian Tomen",
+    "name_plural": "Iranian Toman",
     "price": true
   },
   "ISK": {


### PR DESCRIPTION
commit for #702  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Iranian Toman currency display information, including correction of the currency name and native symbol representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->