### PR TITLE
Community administrators now can use checkorder and checkinvoice commands

### DIFF
--- a/bot/start.ts
+++ b/bot/start.ts
@@ -589,7 +589,10 @@ const initialize = (
       if (order === null) return;
 
       // If the user is a community admin but not a superadmin we need to check the communities match
-      if (!ctx.admin.admin && String(order.community_id) !== String(ctx.admin.default_community_id)) {
+      if (
+        !ctx.admin.admin &&
+        String(order.community_id) !== String(ctx.admin.default_community_id)
+      ) {
         return await messages.notAuthorized(ctx, ctx.admin.tg_id);
       }
 
@@ -613,7 +616,10 @@ const initialize = (
       if (!order.hash) return;
 
       // If the user is a community admin but not a superadmin we need to check the communities match
-      if (!ctx.admin.admin && String(order.community_id) !== String(ctx.admin.default_community_id)) {
+      if (
+        !ctx.admin.admin &&
+        String(order.community_id) !== String(ctx.admin.default_community_id)
+      ) {
         return await messages.notAuthorized(ctx, ctx.admin.tg_id);
       }
 


### PR DESCRIPTION
Before you needed to be superadmin in order been able to run those commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * checkorder and checkinvoice commands are now available to admin users (not just superadmins).

* **Bug Fixes**
  * Non-superadmin admins are now restricted to their assigned community; attempts to check orders/invoices outside that community return a not-authorized response.

* **Chores**
  * Error handling and user-facing behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->