### PR TITLE
fix: initialize `next_arg` with an empty string if `match[2]` is unde…

### DIFF
--- a/bot/middleware/commands.ts
+++ b/bot/middleware/commands.ts
@@ -13,7 +13,7 @@ const commandArgs = () => (ctx: CommunityContext, next: () => void) => {
         if (match[1]) {
           command = match[1];
         }
-        let next_arg = ['', '', match[2]];
+        let next_arg = ['', '', match[2] || ''];
         while ((next_arg = re_next_arg.exec(next_arg[2])!)) {
           let quoted_arg = next_arg[1];
           let unquoted_arg = '';


### PR DESCRIPTION
## Description
This PR fixes a bug in the [commandArgs](cci:1://file:///home/maxi-trabajo/Desktop/lnp2pBot/bot/bot/middleware/commands.ts:2:0-51:2) middleware where commands sent without arguments resulted in the first argument being the literal string `"undefined"`.

## Root Cause
The `RegExp.prototype.exec()` method expects a string. When no arguments were present, `match[2]` was `undefined`. JavaScript coerced this `undefined` value into the string `"undefined"`, which was then matched as a valid argument by the secondary regex.

## Changes
- Updated [bot/middleware/commands.ts](cci:7://file:///home/maxi-trabajo/Desktop/lnp2pBot/bot/bot/middleware/commands.ts:0:0-0:0) to initialize the argument parsing string with an empty string `''` if `match[2]` is null/undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of command argument parsing to prevent potential failures when processing arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->