### PR TITLE
Allow users to use the /setinvoice command on order in status "WAITING_BUYER_INVOICE"

### DIFF
--- a/bot/start.ts
+++ b/bot/start.ts
@@ -135,7 +135,7 @@ const askForConfirmation = async (user: UserDocument, command: string) => {
     } else if (command === '/setinvoice') {
       const where: FilterQuery<OrderQuery> = {
         buyer_id: user._id,
-        status: 'PAID_HOLD_INVOICE',
+        status: { $in: ['PAID_HOLD_INVOICE', 'WAITING_BUYER_INVOICE'] },
       };
 
       orders = await Order.find(where);
@@ -893,7 +893,14 @@ const initialize = (
         throw new Error('ctx.match should not be null');
       }
       ctx.deleteMessage();
-      await addInvoicePHI(ctx, bot, ctx.match[1]);
+      const order = await Order.findOne({ _id: ctx.match[1] });
+      if (!order) return;
+
+      if (order.status === 'WAITING_BUYER_INVOICE') {
+        await addInvoice(ctx, bot, order);
+      } else {
+        await addInvoicePHI(ctx, bot, ctx.match[1]);
+      }
     },
   );
 

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -892,7 +892,6 @@ const initialize = (
       if (ctx.match === null) {
         throw new Error('ctx.match should not be null');
       }
-      ctx.deleteMessage();
       const order = await Order.findOne({ _id: ctx.match[1] });
       if (!order) return;
 


### PR DESCRIPTION
Fixes #718 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice confirmation now recognizes both paid-hold and waiting-buyer orders, improving matching for invoice-related prompts.
  * Invoice action handling now verifies the order exists and routes processing based on order status so invoices are handled correctly for different scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->