### PR TITLE
Update telegraf from 4.8.0 to 4.16.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "nostr-tools": "^2.5.2",
         "qrcode": "^1.5.0",
         "socks-proxy-agent": "^6.2.0-beta.0",
-        "telegraf": "4.8.0",
+        "telegraf": "4.16.3",
         "websocket-polyfill": "0.0.3",
         "winston": "^3.7.2"
       },
@@ -586,6 +586,12 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
+    },
+    "node_modules/@telegraf/types": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
+      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
+      "license": "MIT"
     },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
@@ -4515,11 +4521,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/module-alias": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
-      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q=="
-    },
     "node_modules/module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
@@ -4622,6 +4623,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -6348,31 +6358,26 @@
       }
     },
     "node_modules/telegraf": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.8.0.tgz",
-      "integrity": "sha512-jFcVqYySzRL1zKZSiKKbWbCvarfoF3F6/zEiscDrRbFSAEyGFmpziKWa7pTZeNZezAw1jyp0oI8GEv6JRa4MSg==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
+      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
+      "license": "MIT",
       "dependencies": {
+        "@telegraf/types": "^7.1.0",
         "abort-controller": "^3.0.0",
-        "debug": "^4.3.3",
-        "minimist": "^1.2.6",
-        "module-alias": "^2.2.2",
-        "node-fetch": "^2.6.7",
+        "debug": "^4.3.4",
+        "mri": "^1.2.0",
+        "node-fetch": "^2.7.0",
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2",
-        "typegram": "^3.9.0"
+        "sandwich-stream": "^2.0.2"
       },
       "bin": {
-        "telegraf": "bin/telegraf"
+        "telegraf": "lib/cli.mjs"
       },
       "engines": {
         "node": "^12.20.0 || >=14.13.1"
       }
-    },
-    "node_modules/telegraf/node_modules/typegram": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.12.0.tgz",
-      "integrity": "sha512-/VrU0sJv8BdOsBIpYT4w35C7dPg5YyKP6fLiYN9qYXRZ86TVIiw0ZypkzElTAfDVsJtJSluGAufUrcX7VRSIYQ=="
     },
     "node_modules/telegram-test-api": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "nostr-tools": "^2.5.2",
     "qrcode": "^1.5.0",
     "socks-proxy-agent": "^6.2.0-beta.0",
-    "telegraf": "4.8.0",
+    "telegraf": "4.16.3",
     "websocket-polyfill": "0.0.3",
     "winston": "^3.7.2"
   },


### PR DESCRIPTION
chore: update telegraf from 4.8.0 to 4.16.3
                                                                                                                                                                                                                                            
  Summary         
                                                                                                                                                                                                                                            
  - Bumps telegraf dependency from version 4.8.0 to 4.16.3                                                                                                                                                                                  
  - Updates package-lock.json accordingly                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
   
  Changes                                                                                                                                                                                                                                   
                  
  - package.json: updated telegraf version pin
  - package-lock.json: updated resolved dependency tree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency to latest stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->