### PR TITLE
fix: use yadio /convert endpoint for accurate fiat-to-sats price

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -43,7 +43,7 @@ PENDING_PAYMENT_WINDOW=5
 
 # Fiat currency rate API
 FIAT_RATE_NAME=''
-FIAT_RATE_EP=''
+FIAT_RATE_EP='https://api.yadio.io/convert'
 NODE_ENV='development'
 
 # Expiration time for published order in seconds

--- a/docs/INSTALL.es.md
+++ b/docs/INSTALL.es.md
@@ -144,7 +144,7 @@ CHANNEL='@tu-canal-de-ofertas'
 ADMIN_CHANNEL='-10*****46' 
 HELP_GROUP='@tu-grupo-de-soporte' 
 
-FIAT_RATE_EP='https://api.yadio.io/rate'
+FIAT_RATE_EP='https://api.yadio.io/convert'
 
 DISPUTE_CHANNEL='@tu-canal-de-disputas' 
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -143,7 +143,7 @@ CHANNEL='@your-offers-channel'
 ADMIN_CHANNEL='-10*****46' 
 HELP_GROUP='@your-support-group' 
 
-FIAT_RATE_EP='https://api.yadio.io/rate'
+FIAT_RATE_EP='https://api.yadio.io/convert'
 
 DISPUTE_CHANNEL='@your-dispute-channel' 
 

--- a/util/index.ts
+++ b/util/index.ts
@@ -155,11 +155,13 @@ const getBtcFiatPrice = async (fiatCode: string, fiatAmount: number) => {
     if (!currency.price) return;
     // Before hit the endpoint we make sure the code have only 3 chars
     const code = currency.code.substring(0, 3);
-    const response = await axios.get(`${process.env.FIAT_RATE_EP}/${code}`);
+    const response = await axios.get(
+      `${process.env.FIAT_RATE_EP}/${fiatAmount}/${code}/BTC`
+    );
     if (response.data.error) {
       return 0;
     }
-    const sats = (fiatAmount / response.data.btc) * 100000000;
+    const sats = response.data.result * 100000000;
 
     return Number(sats);
   } catch (error) {

--- a/util/index.ts
+++ b/util/index.ts
@@ -156,7 +156,7 @@ const getBtcFiatPrice = async (fiatCode: string, fiatAmount: number) => {
     // Before hit the endpoint we make sure the code have only 3 chars
     const code = currency.code.substring(0, 3);
     const response = await axios.get(
-      `${process.env.FIAT_RATE_EP}/${fiatAmount}/${code}/BTC`
+      `${process.env.FIAT_RATE_EP}/${fiatAmount}/${code}/BTC`,
     );
     if (response.data.error) {
       return 0;


### PR DESCRIPTION
# Fix VES (and low-liquidity currencies) sats calculation

## Problem

When creating an order with a fiat amount, the bot was calling `https://api.yadio.io/rate/{code}` to get the BTC exchange rate. For currencies without a liquid direct BTC trading pair (most notably VES), yadio returns a rate based on a low-liquidity direct pair and includes a warning in the response: `"currency pair not specified using default"`.

This caused incorrect sats calculations. For example, 1212 VES would return ~2,426 sats from the bot, while yadio.io itself shows ~2,492 sats — a ~2.7% discrepancy.

## Root Cause

The `/rate/VES` endpoint returns a direct VES/BTC pair rate that differs from what yadio.io displays on their website. The website derives the rate through a cross-calculation (VES→USD→BTC), which is more accurate for currencies with low BTC liquidity.

## Fix

Switch to the `/convert/{amount}/{code}/BTC` endpoint, which is purpose-built for this use case and matches the rate shown on yadio.io.

**Before:**
```
GET https://api.yadio.io/rate/VES
sats = (fiatAmount / response.data.btc) * 1e8
```

**After:**
```
GET https://api.yadio.io/convert/1212/VES/BTC
sats = response.data.result * 1e8
```

## ⚠️ Required `.env` change

If you are self-hosting this bot, you must update `FIAT_RATE_EP` in your `.env` file:

```diff
- FIAT_RATE_EP='https://api.yadio.io/rate'
+ FIAT_RATE_EP='https://api.yadio.io/convert'
```

> Without this change the bot will stop returning prices for fiat currencies.

## Files changed

- `util/index.ts` — updated API call and response parsing
- `.env-sample` — updated default value
- `docs/INSTALL.md` and `docs/INSTALL.es.md` — updated documentation