### PR TITLE
feat: re-enable community creation via COMMUNITY_CREATION_ENABLED env…

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -79,6 +79,9 @@ COMMUNITY_TTL=31
 # nostr bot private key
 NOSTR_SK=''
 
+# Enable community creation via the /community command (default: false, opt-in per instance)
+COMMUNITY_CREATION_ENABLED=false
+
 # Number of currencies allowed in a community
 COMMUNITY_CURRENCIES=20
 

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -13,11 +13,14 @@ import * as Scenes from './scenes';
 export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('mycomm', userMiddleware, commands.communityAdmin);
   bot.command('mycomms', userMiddleware, commands.myComms);
-  // TODO: Uncomment when the community wizard is ready
-  // bot.command('community', userMiddleware, async ctx => {
-  //   const { user } = ctx;
-  //   await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', { bot, user });
-  // });
+  if (process.env.COMMUNITY_CREATION_ENABLED === 'true') {
+    bot.command('community', userMiddleware, async ctx => {
+      await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', {
+        bot,
+        user: ctx.user,
+      });
+    });
+  }
   bot.command('setcomm', userMiddleware, commands.setComm);
 
   bot.action(


### PR DESCRIPTION
## Summary

   - Introduces a `COMMUNITY_CREATION_ENABLED` environment variable (default: `false`) that controls whether the
   `/community` command is registered at bot startup
   - Replaces the commented-out `/community` command block in `bot/modules/community/index.ts` with a conditional
   registration guarded by the env var
   - Adds `COMMUNITY_CREATION_ENABLED=false` to `.env-sample` with an explanatory comment

   ## Behavior

   - `COMMUNITY_CREATION_ENABLED=false` (default) — `/community` is not registered; community creation is disabled
   - `COMMUNITY_CREATION_ENABLED=true` — `/community` is registered and users can create communities through the existing
    wizard flow

   The wizard scene itself (`COMMUNITY_WIZARD_SCENE_ID`) is unchanged — it was already fully implemented.

   ## Test plan

   - [x] With `COMMUNITY_CREATION_ENABLED` unset or `false`, confirm `/community` returns no response / unknown command
   - [x] With `COMMUNITY_CREATION_ENABLED=true`, confirm `/community` enters the community creation wizard correctly
   EOF
   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Community creation is now opt-in and can be enabled per instance through environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lnp2pBot/bot/pull/811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->