### PR TITLE
Fix: Restore 'buying' and 'selling' locales lost in pr #770

### DIFF
--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -450,6 +450,8 @@ pending_payment_failed_to_admin: |
   Die Bezahlung der LN-Rechnung für den Auftrag ${orderId} des Benutzers @${username} ist fehlgeschlagen.
 
   Zahlungsversuche: ${attempts}
+selling: Verkaufe
+buying: Kaufe
 selling_sats: Verkaufe Sats
 buying_sats: Kaufe Sats
 receive_payment: Zahlung erhalten

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -456,6 +456,8 @@ pending_payment_failed_to_admin: |
   Payment of the invoice for the Buy order ${orderId} of user @${username} has failed.
 
   Payment attempts: ${attempts}
+selling: Selling
+buying: Buying
 selling_sats: Selling sats
 buying_sats: Buying sats
 showusername_selling_sats: '@${username} is selling sats'

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -451,6 +451,8 @@ pending_payment_failed_to_admin: |
   El pago a la invoice de la compra Id: ${orderId} del usuario @${username} ha fallado!
 
   Intento de pago: ${attempts}
+selling: Vendiendo
+buying: Comprando
 selling_sats: Vendiendo sats
 buying_sats: Comprando sats
 showusername_buying_sats: '@${username} está comprando sats'

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -533,6 +533,8 @@ pending_payment_failed_earnings: |
 pending_payment_failed_to_admin: |
   پرداخت صورتحساب سفارش خرید کاربر @${username} با شناسه ${orderId} شکست خورد.
   تعداد تلاش‌های پرداخت: ${attempts}
+selling: فروختن
+buying: خریدن
 selling_sats: فروش ساتوشی
 buying_sats: خرید ساتوشی
 receive_payment: دریافت وجه

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -449,6 +449,8 @@ pending_payment_failed_to_admin: |
   Le paiement de la facture pour l'offre d'achat ${orderId} de l'utilisateur @${username} a échoué.
 
   Tentatives de paiement : ${attempts}
+selling: Vente
+buying: Achat
 selling_sats: Vente de sats
 buying_sats: Achat de sats
 receive_payment: Réception du paiement

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -447,6 +447,8 @@ pending_payment_failed_to_admin: |
   Il pagamento della invoice per l'ordine di acquisto ${orderId} dell'utente @${username} è fallito.
 
   Payment attempts: ${attempts}
+selling: Vendita
+buying: Acquisto
 selling_sats: Vendita sats
 buying_sats: Acquisto sats
 receive_payment: Ricezione del pagamento

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -447,6 +447,8 @@ pending_payment_failed_to_admin: |
   
   결제 시도 횟수: ${attempts}
 
+selling: 팝니다
+buying: 삽니다
 selling_sats: sats 판매
 buying_sats: sats 구매
 receive_payment: 입금

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -449,6 +449,8 @@ pending_payment_failed_to_admin: |
   Pagamento da fatura para o pedido de compra ${orderId} de usuário @${username} falhou.
 
   Tentativas de pagamento: ${attempts}
+selling: Vendendo
+buying: Comprando
 selling_sats: Vendendo sats
 buying_sats: Comprando sats
 receive_payment: Receber pagamento

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -450,6 +450,8 @@ pending_payment_failed_to_admin: |
   Платеж по счету-фактуре на покупку с идентификатором ${orderId} пользователя @${username} не выполнен!
 
   Попытка оплаты: ${attempts}
+selling: Продаю
+buying: Покупаю
 selling_sats: Продажа сат
 buying_sats: Покупка сат
 receive_payment: Расчет

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -447,6 +447,8 @@ pending_payment_failed_to_admin: |
   Платіж за рахунком-фактурою на покупку з ідентифікатором ${orderId} користувача @${username} не виконаний!
 
   Спроб оплати: ${attempts}
+selling: Продаю
+buying: Купую
 selling_sats: Продаж сатоші
 buying_sats: Купівля сатоші
 receive_payment: Розрахунок


### PR DESCRIPTION
Closes #812 
Fixes the regression introduced in #770 in which the "buying" and "selling" translation entries were deleted, but keep being in the order creation wizzard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added multilingual support for "Selling" and "Buying" trade-type labels across 10 languages including English, German, Spanish, French, Italian, Portuguese, Russian, Ukrainian, Korean, and Persian. Users now have access to consistent, localized terminology for trade operations throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lnp2pBot/bot/pull/813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->