### PR TITLE
chore: configure Dependabot schedule and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # NPM dependencies
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
## Summary

Closes #756

Adds `.github/dependabot.yml` to reduce dependency-update noise and keep CI actions current.

- **npm**: weekly (Mon 06:00 UTC), minor/patch grouped into a single PR, majors stay individual, limit raised to 10
- **github-actions**: weekly (Mon 06:00 UTC), default settings (low volume — only a handful of actions across 4 workflows)
- Conventional `chore` commit prefix and consistent `dependencies` labels per ecosystem

## Why not grouping for github-actions?

This repo uses ~5-8 distinct actions total across all workflows, so individual PRs there are already low-volume and easier to review one-by-one. Keeping the change scoped to what the issue asked for.

## Test plan

- [x] YAML syntax validated locally (`yaml.safe_load`)
- [x] No duplicate Dependabot config in the repo
- [x] Workflows exist under `.github/workflows/` so the `github-actions` ecosystem entry is meaningful
- [ ] After merge: confirm GitHub's Dependabot tab shows no schema errors
- [ ] After merge: confirm next Monday run produces the expected grouped npm PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency management configuration to streamline weekly updates for npm packages and GitHub Actions, ensuring dependencies remain current and secure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lnp2pBot/bot/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->