### PR TITLE
feat: gate /community command behind COMMUNITY_CREATION_ENABLED env var

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -85,6 +85,10 @@ COMMUNITY_CURRENCIES=20
 # Max number of payment methods that can be configured in a community for wizzard selection
 MAX_COMMUNITY_PAYMENT_METHODS=10
 
+# Set to 'true' to enable the /community command (community creation wizard).
+# Default is 'false' — bot operators opt in to expose community creation.
+COMMUNITY_CREATION_ENABLED=false
+
 # List of relays to connect to
 RELAYS='ws://localhost:7000,ws://localhost:8000,ws://localhost:9000'
 

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -13,11 +13,12 @@ import * as Scenes from './scenes';
 export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('mycomm', userMiddleware, commands.communityAdmin);
   bot.command('mycomms', userMiddleware, commands.myComms);
-  // TODO: Uncomment when the community wizard is ready
-  // bot.command('community', userMiddleware, async ctx => {
-  //   const { user } = ctx;
-  //   await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', { bot, user });
-  // });
+  if (process.env.COMMUNITY_CREATION_ENABLED === 'true') {
+    bot.command('community', userMiddleware, async ctx => {
+      const { user } = ctx;
+      await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', { bot, user });
+    });
+  }
   bot.command('setcomm', userMiddleware, commands.setComm);
 
   bot.action(


### PR DESCRIPTION
## Summary

Closes #808

Re-enables the `/community` command (community creation wizard) via a new `COMMUNITY_CREATION_ENABLED` environment variable, defaulting to `false`. The wizard scene itself was already fully implemented in `bot/modules/community/scenes.ts` — only the command registration was commented out as a leftover TODO.

## Changes

- **`.env-sample`**: add `COMMUNITY_CREATION_ENABLED=false` with explanatory comment, placed alongside other community-related env vars
- **`bot/modules/community/index.ts`**: replace the commented-out TODO block with a conditional `bot.command('community', ...)` registration controlled by the new env var
- **No changes** to the wizard scene, middleware, or any other command

## Behavior

| Env var value | Behavior |
|---|---|
| unset / `false` (default) | `/community` is not registered; users typing it get no response |
| `true` | `/community` is registered with the standard `userMiddleware` and enters the existing wizard |

Default is `false` so existing instances continue to behave exactly as before — community creation is opt-in at the instance level.

## Out of scope (deferred follow-up)

The `/community` line still appears in the `/help` text across 9 locale files. Conditionally filtering that line is a separate, larger concern (touches all locale handling) and was kept out of this PR to maintain a focused scope. A follow-up issue will be opened to track it.

## Test plan

- [x] `npm test` — all 126 tests pass on the branch
- [x] Compiled output (`dist/bot/modules/community/index.js`) preserves the gate semantics
- [x] ESLint clean on changed file
- [x] Verified that pre-existing TS errors in the build are unrelated (already on `main` due to mongoose 8 types)
- [ ] After merge: deploy a bot with `COMMUNITY_CREATION_ENABLED=true`, confirm `/community` enters the wizard
- [ ] After merge: deploy a bot without the env var, confirm `/community` is a no-op

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The community creation wizard is now configurable and can be enabled or disabled via environment settings (disabled by default)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lnp2pBot/bot/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->