### PR TITLE
chore: publish Docker image to GHCR on each release

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,64 @@
+name: Publish Docker image to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase repository name
+        id: repo
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ steps.repo.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo "Published with digest ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 permissions:
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -45,7 +47,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         id: build
@@ -53,7 +55,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false


### PR DESCRIPTION
## Summary

Closes #755

Adds `.github/workflows/docker-publish.yaml` to publish multi-arch Docker images to GHCR on tag push.

- **Trigger**: `push: tags: v*` + `workflow_dispatch` fallback (mirrors `release.yaml` for consistency)
- **Image**: built from the existing `Dockerfile` for `linux/amd64` + `linux/arm64`
- **Tags published**: `vX.Y.Z`, `vX.Y`, `latest`
- **Auth**: built-in `GITHUB_TOKEN` (no PAT or secret setup required)
- **Cache**: GitHub Actions cache (`type=gha`, `mode=max`) — cold build ~10 min, warm ~2 min

## Coexistence with `release.yaml`

This workflow runs **independently** from `release.yaml`. Both trigger on the same `v*` tag push but produce different artifacts (GHCR image vs. GitHub Release with changelog). A Docker build failure does not block the GitHub Release — operators always get the source release; the Docker image is an additional convenience artifact.

## Design notes

- **`provenance: false`** — modern Buildx defaults to attaching SLSA provenance, which creates an `unknown/unknown` architecture entry visible in the GHCR package listing. Disabling keeps the listing clean (only `amd64` + `arm64`). Cosign / SLSA `mode=max` can be a separate follow-up.
- **`concurrency` group on `workflow + ref`, `cancel-in-progress: false`** — prevents two parallel runs (e.g. tag push + manual dispatch on the same ref) from racing on the same GHCR tags. `cancel-in-progress: false` because cancelling a publish mid-flight risks registry inconsistency.
- **Explicit lowercase step for the image name** — `github.repository` is `lnp2pBot/bot` (mixed case). GHCR is case-insensitive but Docker convention is lowercase; this avoids confusion in `docker pull` commands.
- **`id: build` + `Image digest` echo step** — exposes `steps.build.outputs.digest` in the workflow log so the published digest is traceable for debugging and release notes.

## Out of scope (explicit)

- README Docker installation section — separate follow-up issue planned
- Image vulnerability scanning (Trivy / Snyk)
- Image signing (cosign / SLSA `mode=max`)
- Modifying `release.yaml`

## Test plan

Local validation already completed:

- [x] YAML syntax validated with Node `js-yaml` (8 steps, top-level keys: `name`, `on`, `concurrency`, `permissions`, `jobs`)
- [x] `actionlint` (via `rhysd/actionlint` Docker image) — clean, including shellcheck SC2086 fix for `$GITHUB_OUTPUT` quoting
- [x] `npm run lint`, `npx prettier --check .`, `npm test` — all green, baseline matches `main`
- [x] **`docker buildx build --platform linux/amd64`** — passes in 3m 46s, image 404 MB, Node v20.20.2 (x64)
- [x] **`docker buildx build --platform linux/arm64`** via QEMU — passes in 26 min, image 408 MB, Node v20.20.2 (arm64). This exercises the `canvas` native build (cairo/pango/giflib) on ARM, which is the main risk surface of multi-arch
- [x] Confirmed `.dockerignore` excludes `.github/` so this workflow does not invalidate Docker build context
- [x] Confirmed no existing `docker-publish.yaml` on `main` (no conflict)

After merge (requires maintainer action — cannot test locally):

- [ ] Maintainer creates next tag (`v0.16.0`) → confirm image appears at `ghcr.io/lnp2pbot/bot:v0.16.0`, `:v0.16`, `:latest`
- [ ] Pull from a clean ARM64 host (e.g. Raspberry Pi) → confirm it runs
- [ ] Pull from a clean AMD64 host → confirm it runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image publishing to GHCR on version tags with multi-arch builds (amd64, arm64).
  * Generates semver-based tags (major.minor, full version) and sets a `latest` tag for v* releases.
  * Supports manual trigger, build caching for faster publishes, and prints the published image digest for easy verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lnp2pBot/bot/pull/818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->