### PR TITLE
fix: use maker's language when republishing order on buyer cancel

### DIFF
--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -369,12 +369,24 @@ const cancelAddInvoice = async (
         order.secret = null;
       }
 
+      const i18nCtxSeller = await getUserI18nContext(sellerUser);
       if (order.type === 'buy') {
         order.seller_id = null;
-        await messages.publishBuyOrderMessage(ctx, user, order, i18nCtx);
+        const i18nCtxBuyer = await getUserI18nContext(buyerUser);
+        await messages.publishBuyOrderMessage(
+          ctx,
+          buyerUser,
+          order,
+          i18nCtxBuyer,
+        );
       } else {
         order.buyer_id = null;
-        await messages.publishSellOrderMessage(ctx, sellerUser, order, i18nCtx);
+        await messages.publishSellOrderMessage(
+          ctx,
+          sellerUser,
+          order,
+          i18nCtxSeller,
+        );
       }
       await order.save();
 


### PR DESCRIPTION
## fix: use maker's language when republishing order on buyer cancel

Closes #820   
  ### Problem

  When a taker with a different language setting cancels an order (causing it to be republished as `PENDING`), the "Buy SAT" / "Sell SAT" button was rendered in the **taker's language** instead of the **maker's language**. This made the
  button inconsistent with the rest of the order content, which was already displayed in the maker's language.

  ### Root Cause

  In `cancelAddInvoice` (`bot/commands.ts`), the republish branch was passing `i18nCtx` (derived from the calling user, i.e. the taker) to both `publishBuyOrderMessage` and `publishSellOrderMessage`. The seller-cancel handler already
  handled this correctly by using `i18nCtxBuyer` / `i18nCtxSeller` based on order type, but the buyer-cancel side never picked up the same pattern.

  ### Fix

  `cancelAddInvoice` now mirrors the seller-cancel pattern:

  - **Buy order** (maker = buyer): resolves `i18nCtxBuyer` from `buyerUser` and passes it to `publishBuyOrderMessage`.
  - **Sell order** (maker = seller): resolves `i18nCtxSeller` from `sellerUser` and passes it to `publishSellOrderMessage`.

  This ensures the button text always matches the maker's configured language, regardless of who takes or cancels the order.

  ### Affected file

  - `bot/commands.ts` — `cancelAddInvoice` function, republish branch (~line 372)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed order re-publication messaging to ensure messages are sent to the correct recipient (buyer or seller) with proper language localization when canceling an invoice.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lnp2pBot/bot/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->