### PR TITLE
feat: add counterparty requirements configuration in /settings

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -73,6 +73,10 @@ PAYMENT_ATTEMPTS=2
 # Here will go the disputes from non community orders
 DISPUTE_CHANNEL='@p2plnbotDispute'
 
+# Maximum values for counterparty requirements that users can set
+MAX_COUNTERPARTY_AGE_REQUIREMENT=30
+MAX_COUNTERPARTY_ORDERS_REQUIREMENT=10
+
 # time-to-live for communities in days, communities without successful orders on this time are deleted
 COMMUNITY_TTL=31
 

--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -975,6 +975,20 @@ const userTakerIsBlockedByUserOrder = async (
   }
 };
 
+const notMeetingRequirementsMessage = async (
+  ctx: MainContext,
+  user: UserDocument,
+) => {
+  try {
+    await ctx.telegram.sendMessage(
+      user.tg_id,
+      ctx.i18n.t('not_meeting_requirements'),
+    );
+  } catch (error) {
+    logger.error(error);
+  }
+};
+
 const fiatSentMessages = async (
   ctx: MainContext,
   buyer: UserDocument,
@@ -2224,4 +2238,5 @@ export {
   userTakerIsBlockedByUserOrder,
   userOrderIsBlockedByUserTaker,
   showQRCodeMessage,
+  notMeetingRequirementsMessage,
 };

--- a/bot/modules/orders/takeOrder.ts
+++ b/bot/modules/orders/takeOrder.ts
@@ -1,7 +1,11 @@
 import { logger } from '../../../logger';
 import { Block, Order, User } from '../../../models';
 import { UserDocument } from '../../../models/user';
-import { deleteOrderFromChannel, generateRandomImage } from '../../../util';
+import {
+  deleteOrderFromChannel,
+  generateRandomImage,
+  getUserAge,
+} from '../../../util';
 import * as messages from '../../messages';
 import { HasTelegram, MainContext } from '../../start';
 import {
@@ -73,6 +77,8 @@ export const takebuy = async (
     if (await isBannedFromCommunity(user, order.community_id))
       return await messages.bannedUserErrorMessage(ctx, user);
 
+    if (!(await meetsCounterpartyRequirements(ctx, user, userOffer))) return;
+
     if (!(await validateTakeBuyOrder(ctx, bot, user, order))) return;
 
     const { randomImage } = generateRandomImage(user._id.toString());
@@ -127,6 +133,9 @@ export const takesell = async (
     // We verify if the user is not banned on this community
     if (await isBannedFromCommunity(user, order.community_id))
       return await messages.bannedUserErrorMessage(ctx, user);
+
+    if (!(await meetsCounterpartyRequirements(ctx, user, seller))) return;
+
     if (!(await validateTakeSellOrder(ctx, bot, user, order))) return;
     order.status = 'WAITING_BUYER_INVOICE';
     order.buyer_id = user._id;
@@ -141,6 +150,34 @@ export const takesell = async (
   } catch (error) {
     logger.error(error);
   }
+};
+
+const meetsCounterpartyRequirements = async (
+  ctx: MainContext,
+  user: UserDocument,
+  orderCreator: UserDocument,
+) => {
+  if (!orderCreator.counterparty_requirements) return true;
+
+  const { min_days_using_bot, min_completed_orders } =
+    orderCreator.counterparty_requirements;
+
+  if (min_days_using_bot > 0) {
+    const ageInDays = getUserAge(user);
+    if (ageInDays < min_days_using_bot) {
+      await messages.notMeetingRequirementsMessage(ctx, user);
+      return false;
+    }
+  }
+
+  if (min_completed_orders > 0) {
+    if (user.trades_completed < min_completed_orders) {
+      await messages.notMeetingRequirementsMessage(ctx, user);
+      return false;
+    }
+  }
+
+  return true;
 };
 
 const checkBlockingStatus = async (

--- a/bot/modules/user/scenes/settings.ts
+++ b/bot/modules/user/scenes/settings.ts
@@ -9,6 +9,11 @@ import {
 import { Message } from 'telegraf/typings/core/types/typegram';
 import { logger } from '../../../../logger';
 
+const readNonNegativeInt = (value: string | undefined, fallback: number) => {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
 function make() {
   const resetMessage = async (ctx: CommunityContext, next: () => void) => {
     const state = ctx.scene.state as CommunityWizardState;
@@ -146,8 +151,9 @@ function make() {
         const [, days] = ctx.message.text.trim().split(' ');
         const min_days = parseInt(days);
         if (isNaN(min_days) || min_days < 0) throw new Error('NotValidNumber');
-        const maxAge = parseInt(
-          process.env.MAX_COUNTERPARTY_AGE_REQUIREMENT || '30',
+        const maxAge = readNonNegativeInt(
+          process.env.MAX_COUNTERPARTY_AGE_REQUIREMENT,
+          30,
         );
         if (min_days > maxAge) {
           state.error = {
@@ -171,7 +177,10 @@ function make() {
       } catch (err) {
         logger.error(err);
         (ctx.scene.state as CommunityWizardState).error = {
-          i18n: 'invalid_number',
+          i18n:
+            err instanceof Error && err.message === 'NotValidNumber'
+              ? 'invalid_number'
+              : 'generic_error',
         };
         await updateMessage(ctx);
       }
@@ -191,8 +200,9 @@ function make() {
         const min_orders = parseInt(orders);
         if (isNaN(min_orders) || min_orders < 0)
           throw new Error('NotValidNumber');
-        const maxOrders = parseInt(
-          process.env.MAX_COUNTERPARTY_ORDERS_REQUIREMENT || '10',
+        const maxOrders = readNonNegativeInt(
+          process.env.MAX_COUNTERPARTY_ORDERS_REQUIREMENT,
+          10,
         );
         if (min_orders > maxOrders) {
           state.error = {
@@ -219,7 +229,10 @@ function make() {
       } catch (err) {
         logger.error(err);
         (ctx.scene.state as CommunityWizardState).error = {
-          i18n: 'invalid_number',
+          i18n:
+            err instanceof Error && err.message === 'NotValidNumber'
+              ? 'invalid_number'
+              : 'generic_error',
         };
         await updateMessage(ctx);
       }

--- a/bot/modules/user/scenes/settings.ts
+++ b/bot/modules/user/scenes/settings.ts
@@ -7,6 +7,7 @@ import {
   CommunityWizardState,
 } from '../../community/communityContext';
 import { Message } from 'telegraf/typings/core/types/typegram';
+import { logger } from '../../../../logger';
 
 function make() {
   const resetMessage = async (ctx: CommunityContext, next: () => void) => {
@@ -24,6 +25,10 @@ function make() {
       npub: '',
       community: '',
       lightning_address: '',
+      min_days_using_bot:
+        user.counterparty_requirements?.min_days_using_bot ?? 0,
+      min_completed_orders:
+        user.counterparty_requirements?.min_completed_orders ?? 0,
     };
     if (user.default_community_id) {
       const community = await Community.findById(user.default_community_id);
@@ -128,6 +133,123 @@ function make() {
       await updateMessage(ctx);
     }
   });
+
+  scene.command(
+    'counterpartyage',
+    resetMessage,
+    async (ctx: CommunityContext) => {
+      try {
+        await ctx.deleteMessage();
+        const state = ctx.scene.state as CommunityWizardState;
+        if (ctx.message === undefined || !('text' in ctx.message))
+          throw new Error('ctx.message is undefined');
+        const [, days] = ctx.message.text.trim().split(' ');
+        const min_days = parseInt(days);
+        if (isNaN(min_days) || min_days < 0) throw new Error('NotValidNumber');
+        const maxAge = parseInt(
+          process.env.MAX_COUNTERPARTY_AGE_REQUIREMENT || '30',
+        );
+        if (min_days > maxAge) {
+          state.error = {
+            i18n: 'invalid_range',
+            command: '/counterpartyage',
+            max: maxAge,
+          };
+          return await updateMessage(ctx);
+        }
+        const user = state.user;
+        if (!user.counterparty_requirements) {
+          user.counterparty_requirements = {
+            min_days_using_bot: 0,
+            min_completed_orders: 0,
+          };
+        }
+        user.counterparty_requirements.min_days_using_bot = min_days;
+        await user.save();
+        state.feedback = { i18n: 'counterpartyage_updated', days: min_days };
+        await updateMessage(ctx);
+      } catch (err) {
+        logger.error(err);
+        (ctx.scene.state as CommunityWizardState).error = {
+          i18n: 'invalid_number',
+        };
+        await updateMessage(ctx);
+      }
+    },
+  );
+
+  scene.command(
+    'counterpartyorders',
+    resetMessage,
+    async (ctx: CommunityContext) => {
+      try {
+        await ctx.deleteMessage();
+        const state = ctx.scene.state as CommunityWizardState;
+        if (ctx.message === undefined || !('text' in ctx.message))
+          throw new Error('ctx.message is undefined');
+        const [, orders] = ctx.message.text.trim().split(' ');
+        const min_orders = parseInt(orders);
+        if (isNaN(min_orders) || min_orders < 0)
+          throw new Error('NotValidNumber');
+        const maxOrders = parseInt(
+          process.env.MAX_COUNTERPARTY_ORDERS_REQUIREMENT || '10',
+        );
+        if (min_orders > maxOrders) {
+          state.error = {
+            i18n: 'invalid_range',
+            command: '/counterpartyorders',
+            max: maxOrders,
+          };
+          return await updateMessage(ctx);
+        }
+        const user = state.user;
+        if (!user.counterparty_requirements) {
+          user.counterparty_requirements = {
+            min_days_using_bot: 0,
+            min_completed_orders: 0,
+          };
+        }
+        user.counterparty_requirements.min_completed_orders = min_orders;
+        await user.save();
+        state.feedback = {
+          i18n: 'counterpartyorders_updated',
+          orders: min_orders,
+        };
+        await updateMessage(ctx);
+      } catch (err) {
+        logger.error(err);
+        (ctx.scene.state as CommunityWizardState).error = {
+          i18n: 'invalid_number',
+        };
+        await updateMessage(ctx);
+      }
+    },
+  );
+
+  scene.command(
+    'resetrequirements',
+    resetMessage,
+    async (ctx: CommunityContext) => {
+      try {
+        await ctx.deleteMessage();
+        const state = ctx.scene.state as CommunityWizardState;
+        const user = state.user;
+        user.counterparty_requirements = {
+          min_days_using_bot: 0,
+          min_completed_orders: 0,
+        };
+        await user.save();
+        state.feedback = { i18n: 'requirements_reset' };
+        await updateMessage(ctx);
+      } catch (err) {
+        logger.error(err);
+        (ctx.scene.state as CommunityWizardState).error = {
+          i18n: 'generic_error',
+        };
+        await updateMessage(ctx);
+      }
+    },
+  );
 
   return scene;
 }

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -251,6 +251,10 @@ help: |
   /setaddress <_lightning Adresse / off_> - Ermöglicht es dem Käufer, eine statische Zahlungsadresse (Lightning-Adresse) einzurichten, _off_ zum Deaktivieren 
   /setlang - Ermöglicht dem Benutzer, die Sprache zu ändern
   /settings - Zeigt die aktuellen Einstellungen des Benutzers an
+  Innerhalb von /settings kannst du Gegenpartei-Anforderungen konfigurieren:
+    /counterpartyage &lt;Tage&gt; - Legt das Mindestalter (in Tagen) für die Gegenpartei fest
+    /counterpartyorders &lt;Aufträge&gt; - Legt die Mindestanzahl abgeschlossener Aufträge für die Gegenpartei fest
+    /resetrequirements - Setzt die Anforderungen auf Standardwerte zurück
   /listorders - Benutze diesen Befehl, um alle deine ausstehenden Transaktionen aufzulisten
   /listcurrencies - Listet alle FIAT Währungen auf, die wir verwenden können 
   /fiatsent <_order id_> - Der Käufer teilt mit, dass er dem Verkäufer das FIAT-Geld geschickt hat
@@ -631,20 +635,33 @@ order_not_found: Bestellung nicht gefunden.
 
 # START modules/user
 user_settings: |
-  <strong>User settings for @${user.username}</strong>
+  <strong>Benutzereinstellungen für @${user.username}</strong>
 
-  Language:
+  Sprache:
     ${language.emoji} ${language.name}
-  Community:
+  Gemeinschaft:
     ${community || '🛇'}
   npub:
     <code>${npub || '🛇'}</code>
-  lightning address:
+  Lightning-Adresse:
     <code>${lightning_address || '🛇'}</code>
 
-  <strong># HELP</strong>
-  /setnpub &lt;npub&gt; - Configure user's Nostr public key.
-  /exit - to exit the wizard.
+  <strong>Gegenpartei-Anforderungen</strong>
+  Mindestalter: ${min_days_using_bot} Tage
+  Mindestanzahl abgeschlossener Aufträge: ${min_completed_orders}
+
+  <strong># HILFE</strong>
+  /setnpub &lt;npub&gt; - Nostr-Schlüssel des Benutzers konfigurieren.
+  /counterpartyage &lt;Tage&gt; - Legt das Mindestalter (in Tagen) für die Gegenpartei fest.
+  /counterpartyorders &lt;Aufträge&gt; - Legt die Mindestanzahl abgeschlossener Aufträge fest.
+  /resetrequirements - Setzt die Gegenpartei-Anforderungen auf Standardwerte zurück.
+  /exit - um den Assistenten zu verlassen.
+not_meeting_requirements: Du erfüllst nicht die Anforderungen der Gegenpartei, um diesen Auftrag anzunehmen.
+counterpartyage_updated: Altersanforderung der Gegenpartei auf ${days} Tage aktualisiert.
+counterpartyorders_updated: Auftragsanforderung der Gegenpartei auf ${orders} aktualisiert.
+requirements_reset: Gegenpartei-Anforderungen wurden auf Standardwerte zurückgesetzt.
+invalid_number: Ungültige Zahl.
+invalid_range: Ungültiger Wert für ${command}, bitte wähle eine Zahl im Bereich [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Rechnung wurde bereits niedergelassen

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -254,7 +254,11 @@ help: |
   /setaddress <_lightning address / off_> - Allows the buyer to establish a static payment address (lightning address), _off_ to deactivate 
   /setlang - Allows the user to change the language
   /settings - Displays the user's current settings
-  /listorders - Use this command to list all your pending transactions 
+  While in /settings you can configure counterparty requirements:
+    /counterpartyage &lt;days&gt; - Sets the minimum account age (in days) required for the counterparty to take your orders
+    /counterpartyorders &lt;orders&gt; - Sets the minimum number of completed orders required for the counterparty
+    /resetrequirements - Resets counterparty requirements to default
+  /listorders - Use this command to list all your pending transactions
   /listcurrencies - Lists all the currencies we can use to without indicatin the amount in sats. 
   /fiatsent <_order id_> - Buyer informs that he has already sent FIAT money to seller
   /release <_order id_> - Seller releases satoshis 
@@ -648,9 +652,22 @@ user_settings: |
   lightning address:
     <code>${lightning_address || '🛇'}</code>
 
+  <strong>Counterparty requirements</strong>
+  Min. account age: ${min_days_using_bot} days
+  Min. completed orders: ${min_completed_orders}
+
   <strong># HELP</strong>
   /setnpub &lt;npub&gt; - Configure user's Nostr public key.
+  /counterpartyage &lt;days&gt; - Sets the minimum account age (in days) for the counterparty.
+  /counterpartyorders &lt;orders&gt; - Sets the minimum number of completed orders for the counterparty.
+  /resetrequirements - Resets counterparty requirements to default.
   /exit - to exit the wizard.
+not_meeting_requirements: You do not meet the counterparty requirements to take this order.
+counterpartyage_updated: Counterparty age requirement updated to ${days} days.
+counterpartyorders_updated: Counterparty completed orders requirement updated to ${orders}.
+requirements_reset: Counterparty requirements have been reset to default.
+invalid_number: Invalid number.
+invalid_range: Invalid value for ${command}, please choose a number in the range [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Invoice already settled

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -251,6 +251,10 @@ help: |
   /setaddress <_lightning address / off_> - Permite al comprador indicar una dirección de pago estática (lightning address), _off_ para desactivarla
   /setlang - Le permite al usuario cambiar el idioma
   /settings - Muestra la configuración actual del usuario
+  Dentro de /settings podés configurar los requisitos de contraparte:
+    /counterpartyage &lt;días&gt; - Establece la antigüedad mínima (en días) requerida para la contraparte
+    /counterpartyorders &lt;órdenes&gt; - Establece el mínimo de órdenes completadas requeridas para la contraparte
+    /resetrequirements - Restablece los requisitos al valor por defecto
   /listorders - El usuario puede listar sus órdenes no finalizadas
   /listcurrencies - Lista las monedas que podemos utilizar sin indicar el monto en satoshis
   /fiatsent <_id orden_> - El comprador indica que ya ha enviado el dinero Fiat al vendedor
@@ -644,9 +648,22 @@ user_settings: |
   lightning address:
     <code>${lightning_address || '🛇'}</code>
 
+  <strong>Requisitos de contraparte</strong>
+  Antigüedad mínima: ${min_days_using_bot} días
+  Órdenes mínimas completadas: ${min_completed_orders}
+
   <strong># AYUDA</strong>
   /setnpub &lt;npub&gt; - Configura la llave pública de Nostr.
+  /counterpartyage &lt;días&gt; - Establece la antigüedad mínima (en días) para la contraparte.
+  /counterpartyorders &lt;órdenes&gt; - Establece el mínimo de órdenes completadas para la contraparte.
+  /resetrequirements - Restablece los requisitos de contraparte al valor por defecto.
   /exit - para salir del asistente.
+not_meeting_requirements: No cumplís los requisitos de la contraparte para tomar esta orden.
+counterpartyage_updated: Requisito de antigüedad de contraparte actualizado a ${days} días.
+counterpartyorders_updated: Requisito de órdenes completadas de contraparte actualizado a ${orders}.
+requirements_reset: Los requisitos de contraparte han sido restablecidos al valor por defecto.
+invalid_number: Número inválido.
+invalid_range: Valor inválido para ${command}, por favor elegí un número en el rango [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Factura ya cobrada

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -283,6 +283,10 @@ help: |
 
   /settings
   تنظیمات کنونی کاربر را نمایش می‌دهد.
+  در /settings می‌توانید الزامات طرف مقابل را تنظیم کنید:
+    /counterpartyage &lt;روز&gt; - حداقل سابقه (به روز) برای طرف مقابل
+    /counterpartyorders &lt;سفارش&gt; - حداقل تعداد سفارش‌های تکمیل شده برای طرف مقابل
+    /resetrequirements - بازگرداندن الزامات به مقادیر پیش‌فرض
 
   /listorders
   از این دستور برای مشاهده لیستی از تمامی سفارش‌ها فعال خود استفاده کنید.
@@ -739,12 +743,26 @@ user_settings: |
   نشانی لایتنینگ:
     <code>${lightning_address || '🛇'}</code>
 
+  <strong>الزامات طرف مقابل</strong>
+  حداقل سابقه: ${min_days_using_bot} روز
+  حداقل سفارش‌های تکمیل شده: ${min_completed_orders}
+
   <strong># راهنما</strong>
   تنظیم کلید عمومی نوستر کاربر:
   /setnpub &lt;npub&gt;
 
+  /counterpartyage &lt;روز&gt; - حداقل سابقه (به روز) برای طرف مقابل.
+  /counterpartyorders &lt;سفارش&gt; - حداقل تعداد سفارش‌های تکمیل شده برای طرف مقابل.
+  /resetrequirements - بازگرداندن الزامات طرف مقابل به مقادیر پیش‌فرض.
+
   خروج از راهنما:
   /exit
+not_meeting_requirements: شما واجد الزامات طرف مقابل برای پذیرش این سفارش نیستید.
+counterpartyage_updated: الزامات سابقه طرف مقابل به ${days} روز به‌روزرسانی شد.
+counterpartyorders_updated: الزامات سفارش‌های تکمیل شده طرف مقابل به ${orders} عدد به‌روزرسانی شد.
+requirements_reset: الزامات طرف مقابل به مقادیر پیش‌فرض بازگردانده شد.
+invalid_number: عدد نامعتبر است.
+invalid_range: مقدار نامعتبر برای ${command}، لطفاً عددی در محدوده [0 - ${max}] انتخاب کنید.
 # END modules/user
 # check hold invoice
 invoice_settled: صورتحساب تسویه شده است.

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -253,7 +253,11 @@ help: |
   /setaddress <_addresse lightning / off_> - Permet à l'acheteur de définir une adresse de paiement statique (adresse lightning), _off_ pour désactiver 
   /setlang - Change la langue de l'interface
   /settings - Affiche tes réglages actuels
-  /listorders - Utilise cette commande pour afficher toutes tes offres en attente 
+  Dans /settings tu peux configurer les exigences de contrepartie:
+    /counterpartyage &lt;jours&gt; - Définit l'âge minimum (en jours) requis pour la contrepartie
+    /counterpartyorders &lt;ordres&gt; - Définit le nombre minimum d'ordres complétés requis pour la contrepartie
+    /resetrequirements - Réinitialise les exigences aux valeurs par défaut
+  /listorders - Utilise cette commande pour afficher toutes tes offres en attente
   /listcurrencies - Lister les devises que nous pouvons utiliser sans spécifier le montant en satoshi. 
   /fiatsent <_order id_> - L'acheteur informe qu'il a déjà envoyé de l'argent FIAT au vendeur
   /release <_order id_> - Le vendeur libère les satoshis 
@@ -641,9 +645,22 @@ user_settings: |
   adresse lightning:
     <code>${lightning_address || '🛇'}</code>
 
+  <strong>Exigences de contrepartie</strong>
+  Âge minimum: ${min_days_using_bot} jours
+  Ordres complétés minimum: ${min_completed_orders}
+
   <strong># AIDE</strong>
-  /setnpub &lt;npub&gt; - Configurer la clé publique de l'utilisateur.
+  /setnpub &lt;npub&gt; - Configurer la clé publique Nostr de l'utilisateur.
+  /counterpartyage &lt;jours&gt; - Définit l'âge minimum (en jours) pour la contrepartie.
+  /counterpartyorders &lt;ordres&gt; - Définit le nombre minimum d'ordres complétés pour la contrepartie.
+  /resetrequirements - Réinitialise les exigences de contrepartie aux valeurs par défaut.
   /exit - pour quitter l'assistant.
+not_meeting_requirements: Vous ne remplissez pas les exigences de la contrepartie pour prendre cet ordre.
+counterpartyage_updated: Exigence d'âge de la contrepartie mise à jour à ${days} jours.
+counterpartyorders_updated: Exigence d'ordres complétés de la contrepartie mise à jour à ${orders}.
+requirements_reset: Les exigences de contrepartie ont été réinitialisées aux valeurs par défaut.
+invalid_number: Nombre invalide.
+invalid_range: Valeur invalide pour ${command}, veuillez choisir un nombre dans la plage [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Facture déjà installée

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -251,6 +251,10 @@ help: |
   /setaddress <_lightning address / off_> - Consente all'acquirente di indicare un indirizzo di pagamento statico (lightning address), _off_ per disattivarlo 
   /setlang - Consente all'utente di cambiare lingua
   /settings - Visualizza le impostazioni correnti dell'utente
+  In /settings puoi configurare i requisiti della controparte:
+    /counterpartyage &lt;giorni&gt; - Imposta l'età minima (in giorni) richiesta per la controparte
+    /counterpartyorders &lt;ordini&gt; - Imposta il numero minimo di ordini completati richiesti per la controparte
+    /resetrequirements - Ripristina i requisiti ai valori predefiniti
   /listorders - Utilizzare questo comando per verificare tutte le transazioni in sospeso
   /listcurrencies - Elenca tutte le valute che si possono usare senza indicare l'importo in sats. 
   /fiatsent <_order id_> - L'acquirente informa che ha inviato FIAT al venditore
@@ -628,20 +632,33 @@ order_not_found: Ordine non trovato.
 
 # START modules/user
 user_settings: |
-  <strong>User settings for @${user.username}</strong>
+  <strong>Impostazioni utente per @${user.username}</strong>
 
-  Language:
+  Lingua:
     ${language.emoji} ${language.name}
-  Community:
+  Comunità:
     ${community || '🛇'}
   npub:
     <code>${npub || '🛇'}</code>
-  lightning address:
+  indirizzo lightning:
     <code>${lightning_address || '🛇'}</code>
 
-  <strong># HELP</strong>
-  /setnpub &lt;npub&gt; - Configure user's Nostr public key.
-  /exit - to exit the wizard.
+  <strong>Requisiti della controparte</strong>
+  Età minima: ${min_days_using_bot} giorni
+  Ordini completati minimi: ${min_completed_orders}
+
+  <strong># AIUTO</strong>
+  /setnpub &lt;npub&gt; - Configura la chiave pubblica Nostr dell'utente.
+  /counterpartyage &lt;giorni&gt; - Imposta l'età minima (in giorni) per la controparte.
+  /counterpartyorders &lt;ordini&gt; - Imposta il numero minimo di ordini completati per la controparte.
+  /resetrequirements - Ripristina i requisiti della controparte ai valori predefiniti.
+  /exit - per uscire dall'assistente.
+not_meeting_requirements: Non soddisfi i requisiti della controparte per accettare questo ordine.
+counterpartyage_updated: Requisito di età della controparte aggiornato a ${days} giorni.
+counterpartyorders_updated: Requisito di ordini completati della controparte aggiornato a ${orders}.
+requirements_reset: I requisiti della controparte sono stati ripristinati ai valori predefiniti.
+invalid_number: Numero non valido.
+invalid_range: Valore non valido per ${command}, scegli un numero nell'intervallo [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Fattura già risolta

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -252,6 +252,10 @@ help: |
   /setaddress <_라이트닝 주소 / off_> - 구매자가 정적인 결제 주소 (라이트닝 주소)를 설정할 수 있게 해 줍니다. 주소 대신 _off_를 넣으면 비활성화됩니다.
   /setlang - 사용자 언어를 변경합니다.
   /settings - 사용자의 현재 설정을 표시합니다.
+  /settings 안에서 거래 상대방 요구 사항을 설정할 수 있습니다:
+    /counterpartyage &lt;일&gt; - 거래 상대방의 최소 가입 기간(일)을 설정합니다
+    /counterpartyorders &lt;주문&gt; - 거래 상대방의 최소 완료 주문 수를 설정합니다
+    /resetrequirements - 요구 사항을 기본값으로 초기화합니다
   /listorders - 대기 중인 결제 내역들을 모두 보려면 이 명령어를 사용하세요.
   /listcurrencies - 사용 가능한 모든 법정화폐 종류를 나열합니다. (sat 단위 제외)
   /fiatsent <_주문 id_> - 구매자가 판매자에게 법정화폐의 지불을 마쳤다고 알려주는 명령어입니다.
@@ -639,9 +643,22 @@ user_settings: |
   라이트닝 주소:
     <code>${lightning_address || '🛇'}</code>
 
+  <strong>거래 상대방 요구 사항</strong>
+  최소 가입 기간: ${min_days_using_bot}일
+  최소 완료 주문 수: ${min_completed_orders}
+
   <strong># 도움말</strong>
-  /setnpub &lt;npub&gt; - 사용자의 nostr 공개키를 설정해주세요. Nostr 이벤트들이 이 공개키로 등록됩니다.
+  /setnpub &lt;npub&gt; - 사용자의 Nostr 공개키를 설정합니다.
+  /counterpartyage &lt;일&gt; - 거래 상대방의 최소 가입 기간(일)을 설정합니다.
+  /counterpartyorders &lt;주문&gt; - 거래 상대방의 최소 완료 주문 수를 설정합니다.
+  /resetrequirements - 거래 상대방 요구 사항을 기본값으로 초기화합니다.
   /exit - 설정 모드 나가기.
+not_meeting_requirements: 귀하는 이 주문을 수락하기 위한 거래 상대방 요구 사항을 충족하지 않습니다.
+counterpartyage_updated: 거래 상대방 가입 기간 요구 사항이 ${days}일로 업데이트되었습니다.
+counterpartyorders_updated: 거래 상대방 완료 주문 수 요구 사항이 ${orders}개로 업데이트되었습니다.
+requirements_reset: 거래 상대방 요구 사항이 기본값으로 초기화되었습니다.
+invalid_number: 유효하지 않은 숫자입니다.
+invalid_range: ${command}의 값이 잘못되었습니다. [0 - ${max}] 사이의 숫자를 선택해 주세요.
 # END modules/user
 # check hold invoice
 invoice_settled: 인보이스가 이미 체결되었습니다.

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -252,6 +252,10 @@ help: |
   /setaddress <lightning address / off> - Permite que o comprador indique um endereço de pagamento estático (lightning address), off para desativá-lo
   /setlang - Permite que o usuário altere o idioma
   /settings - Exibe as configurações atuais do usuário
+  Dentro de /settings você pode configurar os requisitos de contraparte:
+    /counterpartyage &lt;dias&gt; - Define a antiguidade mínima (em dias) exigida para a contraparte
+    /counterpartyorders &lt;ordens&gt; - Define o número mínimo de ordens concluídas exigido para a contraparte
+    /resetrequirements - Redefine os requisitos para os valores padrão
   /listorders - O usuário pode listar seus pedidos inacabados
   /listcurrencies - Lista as moedas que podemos usar sem indicar o valor em satoshis
   /fiatsent <order id> - O comprador indica que já enviou o dinheiro Fiat para o vendedor
@@ -630,20 +634,33 @@ order_not_found: Ordem não encontrada.
 
 # START modules/user
 user_settings: |
-  <strong>User settings for @${user.username}</strong>
+  <strong>Configurações de @${user.username}</strong>
 
-  Language:
+  Idioma:
     ${language.emoji} ${language.name}
-  Community:
+  Comunidade:
     ${community || '🛇'}
   npub:
     <code>${npub || '🛇'}</code>
-  lightning address:
+  endereço lightning:
     <code>${lightning_address || '🛇'}</code>
 
-  <strong># HELP</strong>
-  /setnpub &lt;npub&gt; - Configure user's Nostr public key.
-  /exit - to exit the wizard.
+  <strong>Requisitos de contraparte</strong>
+  Antiguidade mínima: ${min_days_using_bot} dias
+  Ordens concluídas mínimas: ${min_completed_orders}
+
+  <strong># AJUDA</strong>
+  /setnpub &lt;npub&gt; - Configura a chave pública Nostr do usuário.
+  /counterpartyage &lt;dias&gt; - Define a antiguidade mínima (em dias) para a contraparte.
+  /counterpartyorders &lt;ordens&gt; - Define o número mínimo de ordens concluídas para a contraparte.
+  /resetrequirements - Redefine os requisitos de contraparte para os valores padrão.
+  /exit - para sair do assistente.
+not_meeting_requirements: Você não cumpre os requisitos da contraparte para aceitar esta ordem.
+counterpartyage_updated: Requisito de antiguidade da contraparte atualizado para ${days} dias.
+counterpartyorders_updated: Requisito de ordens concluídas da contraparte atualizado para ${orders}.
+requirements_reset: Os requisitos de contraparte foram redefinidos para os valores padrão.
+invalid_number: Número inválido.
+invalid_range: Valor inválido para ${command}, por favor escolha um número no intervalo [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Fatura já liquidada

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -250,6 +250,10 @@ help: |
   /setaddress <_lightning address / off_> - Позволяет покупателю указать статический платежный адрес (lightning address), _off_ - отключить
   /setlang - Позволяет пользователю изменить язык
   /settings - Отображает текущие настройки пользователя
+  В /settings можно настроить требования к контрагенту:
+    /counterpartyage &lt;дней&gt; - Устанавливает минимальный возраст (в днях) для контрагента
+    /counterpartyorders &lt;ордеров&gt; - Устанавливает минимальное количество выполненных ордеров для контрагента
+    /resetrequirements - Сбрасывает требования до значений по умолчанию
   /listorders - Пользователь может перечислить свои незавершенные заявки
   /listcurrencies - Перечислите валюты, которые мы можем использовать без указания суммы в сатоши
   /fiatsent <_order id_> - Покупатель указывает, что уже отправил фиатные деньги продавцу
@@ -631,20 +635,33 @@ order_not_found: Заказ не найден.
 
 # START modules/user
 user_settings: |
-  <strong>User settings for @${user.username}</strong>
+  <strong>Настройки пользователя @${user.username}</strong>
 
-  Language:
+  Язык:
     ${language.emoji} ${language.name}
-  Community:
+  Сообщество:
     ${community || '🛇'}
   npub:
     <code>${npub || '🛇'}</code>
-  lightning address:
+  Lightning-адрес:
     <code>${lightning_address || '🛇'}</code>
 
-  <strong># HELP</strong>
-  /setnpub &lt;npub&gt; - Configure user public key.
-  /exit - to exit the wizard.
+  <strong>Требования к контрагенту</strong>
+  Минимальный возраст: ${min_days_using_bot} дней
+  Минимум выполненных ордеров: ${min_completed_orders}
+
+  <strong># ПОМОЩЬ</strong>
+  /setnpub &lt;npub&gt; - Настроить публичный ключ Nostr пользователя.
+  /counterpartyage &lt;дней&gt; - Устанавливает минимальный возраст (в днях) для контрагента.
+  /counterpartyorders &lt;ордеров&gt; - Устанавливает минимальное количество выполненных ордеров для контрагента.
+  /resetrequirements - Сбрасывает требования к контрагенту до значений по умолчанию.
+  /exit - выйти из мастера.
+not_meeting_requirements: Вы не соответствуете требованиям контрагента для принятия этого ордера.
+counterpartyage_updated: Требование к возрасту контрагента обновлено до ${days} дней.
+counterpartyorders_updated: Требование к выполненным ордерам контрагента обновлено до ${orders}.
+requirements_reset: Требования к контрагенту сброшены до значений по умолчанию.
+invalid_number: Неверное число.
+invalid_range: Недопустимое значение для ${command}, пожалуйста, выберите число в диапазоне [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Invoice already settled

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -250,6 +250,10 @@ help: |
   /setaddress <_lightning address / off_> - Дозволяє покупцеві вказати статичну платіжну адресу (lightning address), _off_ - відключено
   /setlang - Дозволяє користувачеві змінювати мову
   /settings - відображає поточні налаштування користувача
+  У /settings можна налаштувати вимоги до контрагента:
+    /counterpartyage &lt;днів&gt; - Встановлює мінімальний вік (у днях) для контрагента
+    /counterpartyorders &lt;ордерів&gt; - Встановлює мінімальну кількість виконаних ордерів для контрагента
+    /resetrequirements - Скидає вимоги до значень за замовчуванням
   /listorders - Використовуйте цю команду, щоб переглянути всі Ваші транзакції, що очікують на розгляд.
   /listcurrencies - Перелічує всі валюти, які ми можемо використовувати, не вказуючи суми в сатоші
   /fiatsent <_order id_> - Покупець повідомляє, що вже відправив фіатні гроші продавцю
@@ -627,20 +631,33 @@ order_not_found: Замовлення не знайдено.
 
 # START modules/user
 user_settings: |
-  <strong>User settings for @${user.username}</strong>
+  <strong>Налаштування користувача @${user.username}</strong>
 
-  Language:
+  Мова:
     ${language.emoji} ${language.name}
-  Community:
+  Спільнота:
     ${community || '🛇'}
   npub:
     <code>${npub || '🛇'}</code>
-  lightning address:
+  Lightning-адреса:
     <code>${lightning_address || '🛇'}</code>
 
-  <strong># HELP</strong>
-  /setnpub &lt;npub&gt; - Configure user's Nostr public key.
-  /exit - to exit the wizard.
+  <strong>Вимоги до контрагента</strong>
+  Мінімальний вік: ${min_days_using_bot} днів
+  Мінімум виконаних ордерів: ${min_completed_orders}
+
+  <strong># ДОПОМОГА</strong>
+  /setnpub &lt;npub&gt; - Налаштувати публічний ключ Nostr користувача.
+  /counterpartyage &lt;днів&gt; - Встановлює мінімальний вік (у днях) для контрагента.
+  /counterpartyorders &lt;ордерів&gt; - Встановлює мінімальну кількість виконаних ордерів для контрагента.
+  /resetrequirements - Скидає вимоги до контрагента до значень за замовчуванням.
+  /exit - вийти з майстра.
+not_meeting_requirements: Ви не відповідаєте вимогам контрагента для прийняття цього ордера.
+counterpartyage_updated: Вимогу до віку контрагента оновлено до ${days} днів.
+counterpartyorders_updated: Вимогу до виконаних ордерів контрагента оновлено до ${orders}.
+requirements_reset: Вимоги до контрагента скинуто до значень за замовчуванням.
+invalid_number: Невірне число.
+invalid_range: Недопустиме значення для ${command}, будь ласка, виберіть число в діапазоні [0 - ${max}].
 # END modules/user
 # check hold invoice
 invoice_settled: Invoice already settled

--- a/models/user.ts
+++ b/models/user.ts
@@ -25,6 +25,10 @@ export interface UserDocument extends Document {
   disputes: number;
   created_at: Date;
   default_community_id?: string;
+  counterparty_requirements?: {
+    min_days_using_bot: number;
+    min_completed_orders: number;
+  };
 }
 
 const UserReviewSchema = new Schema<UserReview>({
@@ -51,6 +55,10 @@ const UserSchema = new Schema<UserDocument>({
   disputes: { type: Number, min: 0, default: 0 },
   created_at: { type: Date, default: Date.now },
   default_community_id: { type: String },
+  counterparty_requirements: {
+    min_days_using_bot: { type: Number, min: 0, default: 0 },
+    min_completed_orders: { type: Number, min: 0, default: 0 },
+  },
 });
 
 export default mongoose.model<UserDocument>('User', UserSchema);

--- a/models/user.ts
+++ b/models/user.ts
@@ -56,8 +56,11 @@ const UserSchema = new Schema<UserDocument>({
   created_at: { type: Date, default: Date.now },
   default_community_id: { type: String },
   counterparty_requirements: {
-    min_days_using_bot: { type: Number, min: 0, default: 0 },
-    min_completed_orders: { type: Number, min: 0, default: 0 },
+    type: {
+      min_days_using_bot: { type: Number, min: 0, default: 0 },
+      min_completed_orders: { type: Number, min: 0, default: 0 },
+    },
+    required: false,
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lnp2pbot",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lnp2pbot",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@grammyjs/i18n": "^0.5.1",


### PR DESCRIPTION
## Summary
  
  Adds counterparty requirements to the `/settings` wizard. Users can now set minimum conditions that must be met before someone can take their orders.

  ## What's new

  - `/counterpartyage <days>` — sets the minimum account age (in days) required for the counterparty
  - `/counterpartyorders <orders>` — sets the minimum number of completed orders required for the counterparty
  - `/resetrequirements` — resets both values back to 0

  The `/settings` panel now shows the current requirements. If a user tries to take an order and doesn't meet the maker's requirements, they receive a notification and the order stays listed.

  ## Environment variables
  
  Two new optional variables can be added to `.env` to cap the maximum values users can set:

  ```env
  MAX_COUNTERPARTY_AGE_REQUIREMENT=30
  MAX_COUNTERPARTY_ORDERS_REQUIREMENT=10

  Languages

  All 10 supported languages updated (en, es, de, fr, it, pt, ru, uk, ko, fa).

  Closes
  
  Fixes #648
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can set minimum counterparty account age and minimum completed orders to control who may take their trades
  * New settings commands: /counterpartyage, /counterpartyorders, /resetrequirements
  * Order acceptance now checks configured counterparty requirements and notifies users when a taker doesn't meet them

* **Localization**
  * Full translated help and UI text for these settings across multiple languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->