### PR TITLE
feat: add DISABLE_LN_ADDRESS kill-switch for Lightning Address payouts

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -70,6 +70,11 @@ BOT_HANDLER_TIMEOUT=60000
 # Attempts to pay the invoice again when the payment failed
 PAYMENT_ATTEMPTS=2
 
+# Temporary kill-switch to disable Lightning Address payouts (security mitigation).
+# When set to "true", buyers must paste a regular BOLT11 invoice; saved Lightning
+# Addresses are kept and ignored. Leave empty/unset to keep Lightning Address enabled.
+DISABLE_LN_ADDRESS=
+
 # Here will go the disputes from non community orders
 DISPUTE_CHANNEL='@p2plnbotDispute'
 

--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -178,7 +178,19 @@ const addInvoice = async (
     const seller = await User.findOne({ _id: order.seller_id });
     if (seller === null) throw new Error('seller was not found');
 
-    if (buyer.lightning_address) {
+    // Temporary mitigation: when DISABLE_LN_ADDRESS is enabled we skip the
+    // Lightning Address auto-resolution and route the buyer to the manual
+    // BOLT11 invoice flow. We do NOT delete the saved address, so this is
+    // fully reversible by unsetting the flag.
+    const lnAddressDisabled = process.env.DISABLE_LN_ADDRESS === 'true';
+    if (buyer.lightning_address && lnAddressDisabled) {
+      await bot.telegram.sendMessage(
+        buyer.tg_id,
+        ctx.i18n.t('ln_address_temporarily_disabled'),
+      );
+    }
+
+    if (buyer.lightning_address && !lnAddressDisabled) {
       const laRes = await resolvLightningAddress(
         buyer.lightning_address,
         order.amount * 1000,

--- a/bot/scenes.ts
+++ b/bot/scenes.ts
@@ -61,6 +61,12 @@ const addInvoiceWizard = new Scenes.WizardScene(
 
       let lnInvoice = ctx.message.text.trim();
       const isValidLN = await validateLightningAddress(lnInvoice);
+      // Temporary mitigation: Lightning Address payouts are disabled.
+      // The buyer can still receive sats by pasting a regular BOLT11 invoice.
+      if (isValidLN && process.env.DISABLE_LN_ADDRESS === 'true') {
+        await ctx.reply(ctx.i18n.t('ln_address_temporarily_disabled'));
+        return;
+      }
       let res: InvoiceParseResult = {};
       if (isValidLN) {
         const laRes = await resolvLightningAddress(
@@ -128,6 +134,12 @@ const addInvoicePHIWizard = new Scenes.WizardScene(
 
       let lnInvoice = ctx.message.text.trim();
       const isValidLN = await validateLightningAddress(lnInvoice);
+      // Temporary mitigation: Lightning Address payouts are disabled.
+      // The buyer can still receive sats by pasting a regular BOLT11 invoice.
+      if (isValidLN && process.env.DISABLE_LN_ADDRESS === 'true') {
+        await ctx.reply(ctx.i18n.t('ln_address_temporarily_disabled'));
+        return;
+      }
       let res: InvoiceParseResult = {};
       if (isValidLN) {
         const laRes = await resolvLightningAddress(

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -243,6 +243,7 @@ must_be_valid_currency: 'Fiat_code must be a valid code, for example: USD, EUR. 
 must_be_number_or_range: 'Fiat_amount must be a number or numeric range in the  <minimum>-<maximum> format'
 invalid_lightning_address: Invalid lightning address
 unavailable_lightning_address: Unavailable lightning address ${la}
+ln_address_temporarily_disabled: ⚠️ Lightning Address payouts are temporarily disabled for maintenance. Please send a regular Lightning invoice (BOLT11) for the exact order amount to receive your sats.
 help: |
   /sell <_sats amount_> <_fiat amount_> <_fiat code_> <_payment method_> [premium/discount] - Creates a Sell order
   /buy <_sats amount_> <_fiat amount_> <_Fiat code_> <_payment method_> [premium/discount] - Creates a Purchase Order

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -240,6 +240,7 @@ must_be_valid_currency: 'codigo_fiat debe ser un código de moneda válido, ejem
 must_be_number_or_range: 'monto_en_fiat debe ser un número o un rango numerico de la forma: <mínimo>-<máximo>.'
 invalid_lightning_address: Dirección lightning no válida
 unavailable_lightning_address: Dirección lightning ${la} no disponible
+ln_address_temporarily_disabled: ⚠️ Los pagos a Lightning Address están temporalmente deshabilitados por mantenimiento. Por favor envía una factura Lightning normal (BOLT11) por el monto exacto de la orden para recibir tus sats.
 help: |
   /sell <_monto en sats_> <_monto en fiat_> <_código fiat_> <_método de pago_> [prima/descuento] - Crea una orden de venta
   /buy <_monto en sats_> <_monto en fiat_> <_código fiat_> <_método de pago_> [prima/descuento] - Crea una orden de compra

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lnp2pbot",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lnp2pbot",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@grammyjs/i18n": "^0.5.1",


### PR DESCRIPTION
## Summary

Adds a temporary, reversible **kill-switch** to disable Lightning Address payouts as a security mitigation. When `DISABLE_LN_ADDRESS=true`, buyers are routed to the manual BOLT11 invoice flow instead of having their saved Lightning Address auto-resolved and paid.

## Motivation

Provides operators a way to quickly shut off the Lightning Address payout path (e.g. in response to a security concern) without code changes or losing user data.

## Changes

- **`bot/commands.ts`** — guards the auto-resolution path in `addInvoice`; when disabled, notifies the buyer and falls back to the manual invoice wizard.
- **`bot/scenes.ts`** — guards both `addInvoiceWizard` and `addInvoicePHIWizard` so a pasted Lightning Address is rejected with a notice while BOLT11 invoices keep working.
- **`.env-sample`** — documents the new `DISABLE_LN_ADDRESS` flag.
- **`locales/en.yaml`, `locales/es.yaml`** — adds the `ln_address_temporarily_disabled` user-facing notice.

## Safety / behavior

- **Complete coverage:** all three `resolvLightningAddress` call sites are guarded by the flag.
- **BOLT11 unaffected:** `validateLightningAddress` only matches the `name@domain` pattern (+ DNS check), so regular invoices flow through normally — users can still receive sats.
- **Reversible:** saved Lightning Addresses are kept and merely ignored; unsetting the flag restores prior behavior with no migration.
- **Safe default:** unset/empty keeps Lightning Address enabled — no behavior change unless explicitly activated. The check is a strict `=== 'true'` match.

## Notes

- Locale strings were added for `en` and `es`; other languages fall back to the default locale. Happy to add the remaining locales if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to temporarily disable Lightning Address payouts, requiring users to provide a standard BOLT11 invoice instead.

* **Documentation**
  * Added English and Spanish translations for the Lightning Address disabled message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->