### PR TITLE
feat: enforce invoice amount matches order amount on payouts

### DIFF
--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -195,7 +195,7 @@ const addInvoice = async (
         buyer.lightning_address,
         order.amount * 1000,
       );
-      if (!!laRes && !laRes.pr) {
+      if (!laRes || !laRes.pr) {
         logger.error(
           `lightning address ${buyer.lightning_address} not available`,
         );

--- a/bot/scenes.ts
+++ b/bot/scenes.ts
@@ -73,6 +73,12 @@ const addInvoiceWizard = new Scenes.WizardScene(
           lnInvoice,
           order.amount * 1000,
         );
+        if (!laRes || !laRes.pr) {
+          await ctx.reply(
+            ctx.i18n.t('unavailable_lightning_address', { la: lnInvoice }),
+          );
+          return;
+        }
         lnInvoice = laRes.pr;
         res.invoice = parsePaymentRequest({ request: lnInvoice });
       } else {
@@ -146,6 +152,12 @@ const addInvoicePHIWizard = new Scenes.WizardScene(
           lnInvoice,
           order.amount * 1000,
         );
+        if (!laRes || !laRes.pr) {
+          await ctx.reply(
+            ctx.i18n.t('unavailable_lightning_address', { la: lnInvoice }),
+          );
+          return;
+        }
         lnInvoice = laRes.pr;
         res.invoice = parsePaymentRequest({ request: lnInvoice });
       } else {

--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -60,7 +60,6 @@ export const attemptPendingPayments = async (
           `attemptPendingPayments: amount mismatch for order ${order._id} ` +
             `(pending ${pending.amount} != order ${order.amount}); stopping retries`,
         );
-        await pending.save();
         continue;
       }
 

--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -35,7 +35,7 @@ export const attemptPendingPayments = async (
         pending.paid = true;
         await pending.save();
         logger.info(`Order id: ${order._id} was already paid`);
-        return;
+        continue;
       }
       // We check if the old payment is on flight
       const isPendingOldPayment: boolean = await isPendingPayment(
@@ -48,7 +48,21 @@ export const attemptPendingPayments = async (
       );
 
       // If one of the payments is on flight we don't do anything
-      if (isPending || isPendingOldPayment) return;
+      if (isPending || isPendingOldPayment) continue;
+
+      // SECURITY (defense in depth): the amount to pay must equal the order
+      // amount. payRequest also enforces this, but we stop retries early here
+      // so a structurally-wrong pending payment is never re-attempted.
+      if (pending.amount !== order.amount) {
+        pending.last_error = 'AMOUNT_MISMATCH';
+        pending.is_invoice_expired = true; // prevents further retries
+        logger.error(
+          `attemptPendingPayments: amount mismatch for order ${order._id} ` +
+            `(pending ${pending.amount} != order ${order.amount}); stopping retries`,
+        );
+        await pending.save();
+        continue;
+      }
 
       const payment = await payRequest({
         amount: pending.amount,
@@ -61,12 +75,13 @@ export const attemptPendingPayments = async (
       if (!!payment && payment.is_expired) {
         pending.is_invoice_expired = true;
         order.paid_hold_buyer_invoice_updated = false;
-        return await messages.expiredInvoiceOnPendingMessage(
+        await messages.expiredInvoiceOnPendingMessage(
           bot,
           buyerUser,
           order,
           i18nCtx,
         );
+        continue;
       }
 
       if (!!payment && !!payment.confirmed_at) {
@@ -111,6 +126,12 @@ export const attemptPendingPayments = async (
           } else if (payment.error === 'ROUTING_FAILED') {
             logger.warning(
               `Routing failed for order ${order._id}, attempt ${pending.attempts}`,
+            );
+          } else if (payment.error === 'AMOUNT_MISMATCH') {
+            // Structural error: never retry an invoice with the wrong amount.
+            pending.is_invoice_expired = true;
+            logger.error(
+              `AMOUNT_MISMATCH for order ${order._id}; stopping retries`,
             );
           } else {
             logger.error(

--- a/ln/pay_request.ts
+++ b/ln/pay_request.ts
@@ -43,6 +43,21 @@ const payRequest = async ({
     // If the invoice is expired we return is_expired = true
     if (invoice.is_expired) return invoice;
 
+    // SECURITY: never pay an amount different from the order amount.
+    // If the invoice encodes an amount, it MUST match the expected amount
+    // exactly. This prevents an attacker from supplying an inflated invoice
+    // (e.g. via a malicious LNURL/Lightning Address endpoint) and draining
+    // the node by being paid more than was held from the seller.
+    if (invoice.tokens && invoice.tokens !== amount) {
+      logger.error(
+        `payRequest: invoice amount (${invoice.tokens}) does not match the expected amount (${amount}); refusing to pay`,
+      );
+      return {
+        error: 'AMOUNT_MISMATCH',
+        message: 'invoice amount does not match order amount',
+      };
+    }
+
     const maxRoutingFee = process.env.MAX_ROUTING_FEE;
     if (maxRoutingFee === undefined)
       throw new Error('Environment variable MAX_ROUTING_FEE is not defined');
@@ -147,6 +162,21 @@ const payToBuyer = async (bot: HasTelegram, order: IOrder) => {
       );
       await messages.rateUserMessage(bot, buyerUser, order, i18nCtx);
     } else {
+      // SECURITY: a structural amount mismatch must never be retried — the
+      // invoice itself is wrong. Alert and stop instead of scheduling a retry,
+      // otherwise the pending payments job would keep attempting to pay it.
+      if (
+        payment &&
+        typeof payment === 'object' &&
+        'error' in payment &&
+        payment.error === 'AMOUNT_MISMATCH'
+      ) {
+        logger.error(
+          `payToBuyer: AMOUNT_MISMATCH for order ${order._id}; refusing to pay and not scheduling a retry`,
+        );
+        await messages.invoicePaymentFailedMessage(bot, buyerUser, i18nCtx);
+        return;
+      }
       // Handle different types of payment failures
       if (payment && typeof payment === 'object' && 'error' in payment) {
         const errorType = payment.error as string;

--- a/lnurl/lnurl-pay.ts
+++ b/lnurl/lnurl-pay.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { logger } from '../logger';
+// @ts-ignore
+const { parsePaymentRequest } = require('invoices');
 
 // {
 //	pr: String, // bech32-serialized lightning invoice
@@ -27,6 +29,29 @@ const resolvLightningAddress = async (address: string, amountMsat: number) => {
   const res = (
     await axios.get(`${lnAddressRes.callback}${'?'}amount=${amountMsat}`)
   ).data;
+
+  // SECURITY: do not trust the amount the server claims via min/maxSendable.
+  // Verify the returned invoice actually encodes the exact requested amount,
+  // otherwise a malicious LNURL endpoint could return an inflated invoice.
+  if (res && res.pr) {
+    try {
+      const parsed = parsePaymentRequest({ request: res.pr });
+      const prMsat = parsed.mtokens
+        ? Number(parsed.mtokens)
+        : (parsed.tokens || 0) * 1000;
+      if (prMsat !== amountMsat) {
+        logger.error(
+          `resolvLightningAddress: returned invoice amount ${prMsat} msat does not match requested ${amountMsat} msat`,
+        );
+        return false;
+      }
+    } catch (error) {
+      logger.error(
+        `resolvLightningAddress: could not parse returned invoice: ${error}`,
+      );
+      return false;
+    }
+  }
 
   return res;
 };


### PR DESCRIPTION
## Summary

Defense-in-depth so the bot **never pays an invoice whose amount differs from the order amount**. This closes a path where a malicious LNURL / Lightning Address endpoint could return an inflated invoice and get paid more than was held from the seller — draining the node.

## Changes

- **`ln/pay_request.ts`**
  - `payRequest` refuses to pay when the invoice encodes an amount that does not equal the expected amount, returning an `AMOUNT_MISMATCH` error.
  - `payToBuyer` treats `AMOUNT_MISMATCH` as a *structural* failure: it alerts the buyer and does **not** schedule a retry (a wrong invoice will never succeed).
- **`lnurl/lnurl-pay.ts`**
  - `resolvLightningAddress` parses the returned invoice and rejects it (`return false`) unless it encodes **exactly** the requested msat amount, instead of trusting the server's `min/maxSendable`.
- **`jobs/pending_payments.ts`**
  - Stops retrying a pending payment whose amount no longer matches the order amount (marked non-retryable).
  - Fixes early `return` → `continue` so a single skipped/already-paid pending payment no longer aborts processing of the rest of the queue.
- **`bot/scenes.ts`**
  - Both `addInvoice` wizards bail out with the `unavailable_lightning_address` notice when LNURL resolution returns no usable invoice, instead of dereferencing a missing `pr`.
- **`bot/commands.ts`**
  - Corrects the unavailable-address guard to also handle a null/undefined resolution result (`!laRes || !laRes.pr`).

## Validation

- `npx tsc --noEmit` — passes
- `npm run lint` — clean
- `npm run format` / prettier check — clean
- `npm test` — 126 passing

## Notes

- Complements PR #830 (`DISABLE_LN_ADDRESS` kill-switch): that flag lets operators turn the feature off entirely, while this PR hardens the path that stays on.
- Reuses the existing `unavailable_lightning_address` and `invoicePaymentFailedMessage` strings — no new locale keys required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lightning Address resolution to detect unavailable or incomplete responses and notify users instead of proceeding.
  * Continued processing of pending payments so one failed/skipped item no longer stops the whole job.
  * Added invoice amount verification to prevent paying mismatched invoices and surface clear errors.
  * Updated handling for expired or invalid invoices with clearer user notifications and no automatic retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->