### PR TITLE
fix: enforce community ownership on earnings withdrawal

### DIFF
--- a/bot/modules/community/actions.ts
+++ b/bot/modules/community/actions.ts
@@ -128,8 +128,13 @@ export const onSetCommunity = async (ctx: CommunityContext) => {
 
 export const withdrawEarnings = async (ctx: CommunityContext) => {
   ctx.deleteMessage();
+  // Only the community creator may withdraw its earnings. The community id
+  // comes from the callback data, so we scope the lookup by creator_id to
+  // match the other community-management handlers (deleteCommunity,
+  // changeVisibility, updateCommunity).
   const community = await Community.findOne({
     _id: ctx.match?.[1],
+    creator_id: ctx.user._id,
     enabled: { $ne: false },
   });
   if (!community) return ctx.reply(ctx.i18n.t('community_not_found'));


### PR DESCRIPTION
## What

The `withdrawEarnings` action looked up the target community using only the id taken from the inline-button callback data, without verifying that the caller owns that community. This change scopes the lookup by `creator_id` as well, so only the community creator can start a withdrawal of its earnings.

## Why

Every other community-management handler (`deleteCommunity`, `changeVisibility`, `updateCommunity`) already filters by `creator_id: ctx.user._id`. The earnings-withdrawal path was the only one missing that ownership check, leaving it inconsistent with the rest of the module. Scoping the query keeps authorization consistent across all community operations.

## Change

`bot/modules/community/actions.ts` — add `creator_id: ctx.user._id` to the `Community.findOne` lookup in `withdrawEarnings`.

## Testing

- `npx tsc --noEmit` passes.
- `npx eslint bot/modules/community/actions.ts` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Earnings withdrawal from communities is now restricted to community creators only, preventing unauthorized withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->