### PR TITLE
fix: verify buyer ownership before entering the setinvoice flow

### DIFF
--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -668,6 +668,11 @@ const addInvoicePHI = async (
     // only orders with status PAID_HOLD_INVOICE are released payments
     if (order.status !== 'PAID_HOLD_INVOICE') return;
 
+    // Only the order's buyer may (re)submit the payout invoice. The order id
+    // comes from the callback data, so we verify the caller is the buyer
+    // before entering the invoice flow.
+    if (!ctx.user || String(order.buyer_id) !== String(ctx.user._id)) return;
+
     const buyer = await User.findOne({ _id: order.buyer_id });
     if (buyer === null) return;
     if (order.amount === 0) {

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -895,6 +895,11 @@ const initialize = (
       const order = await Order.findOne({ _id: ctx.match[1] });
       if (!order) return;
 
+      // Only the order's buyer may set/replace the payout invoice. The order
+      // id comes from the callback data, so we verify the caller is the buyer
+      // before driving the invoice flow.
+      if (String(order.buyer_id) !== String(ctx.user._id)) return;
+
       if (order.status === 'WAITING_BUYER_INVOICE') {
         await addInvoice(ctx, bot, order);
       } else {


### PR DESCRIPTION
## What

The `addInvoicePHI` handler (`bot/commands.ts`) and the `setinvoice_` action (`bot/start.ts`) looked up the order using the id carried in the inline-button callback data and then entered the invoice flow, without checking that the caller is the order's buyer. This adds an explicit ownership check in both entry points so only the buyer can set or replace the payout invoice of their order.

## Why

The payout invoice is the destination of the order's funds, so only the buyer should be able to provide or change it. Both entry points resolved the order purely from the callback id and trusted it, while the rest of the buyer-facing commands are scoped to the acting user. This brings these two paths in line with that model.

## Change

- `bot/commands.ts` — in `addInvoicePHI`, return early unless `ctx.user` is the order's `buyer_id`.
- `bot/start.ts` — in the `setinvoice_` action, return early unless `ctx.user` is the order's `buyer_id`.

## Testing

- `npx tsc --noEmit` passes.
- `npx eslint bot/commands.ts bot/start.ts` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for invoice payment operations by implementing buyer authorization verification. Only the order's buyer can now initiate or modify payout invoice details, preventing unauthorized access to sensitive payment information and ensuring proper transaction safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->