### PR TITLE
fix: prevent double withdrawal of community earnings

### DIFF
--- a/bot/modules/community/scenes.ts
+++ b/bot/modules/community/scenes.ts
@@ -1035,18 +1035,28 @@ export const addEarningsInvoiceWizard = new Scenes.WizardScene(
       if (claimed === null)
         return await ctx.reply(ctx.i18n.t('invoice_already_being_paid'));
 
-      const user = await User.findById(community.creator_id);
-      if (user === null) throw new Error('user was not found');
-      logger.debug(`Creating pending payment for community ${community.id}`);
-      const pp = new PendingPayment({
-        amount: amountToWithdraw,
-        payment_request: lnInvoice,
-        user_id: user.id,
-        community_id: community._id,
-        description: `Retiro por admin @${user.username}`,
-        hash: res.invoice.hash,
-      });
-      await pp.save();
+      // The earnings were already claimed (zeroed) above. If creating the
+      // pending payment fails there is nothing for the retry job to restore
+      // from, so roll the claim back here to avoid stranding the earnings.
+      try {
+        const user = await User.findById(community.creator_id);
+        if (user === null) throw new Error('user was not found');
+        logger.debug(`Creating pending payment for community ${community.id}`);
+        const pp = new PendingPayment({
+          amount: amountToWithdraw,
+          payment_request: lnInvoice,
+          user_id: user.id,
+          community_id: community._id,
+          description: `Retiro por admin @${user.username}`,
+          hash: res.invoice.hash,
+        });
+        await pp.save();
+      } catch (error) {
+        await Community.findByIdAndUpdate(community._id, {
+          $inc: { earnings: amountToWithdraw },
+        });
+        throw error;
+      }
       await ctx.reply(ctx.i18n.t('invoice_updated_and_will_be_paid'));
 
       return ctx.scene.leave();

--- a/bot/modules/community/scenes.ts
+++ b/bot/modules/community/scenes.ts
@@ -1004,7 +1004,9 @@ export const addEarningsInvoiceWizard = new Scenes.WizardScene(
       const res = await isValidInvoice(ctx, lnInvoice);
       if (!res.success) return;
 
-      if (!!res.invoice.tokens && res.invoice.tokens !== community.earnings)
+      const amountToWithdraw = community.earnings;
+
+      if (!!res.invoice.tokens && res.invoice.tokens !== amountToWithdraw)
         return await ctx.reply(ctx.i18n.t('invoice_with_incorrect_amount'));
 
       const isScheduled = await PendingPayment.findOne({
@@ -1019,11 +1021,25 @@ export const addEarningsInvoiceWizard = new Scenes.WizardScene(
       if (!!isScheduled || !!isPending)
         return await ctx.reply(ctx.i18n.t('invoice_already_being_paid'));
 
+      // SECURITY: atomically claim the earnings before scheduling the payout.
+      // We zero the community's earnings only if they still equal the amount
+      // we snapshotted. Two concurrent withdrawals race on this compare-and-set
+      // and only one wins; the loser gets null and aborts, which prevents the
+      // node from paying the same earnings twice. If the payout later fails
+      // permanently the job restores the earnings (see attemptCommunities-
+      // PendingPayments) so the creator can withdraw again.
+      const claimed = await Community.findOneAndUpdate(
+        { _id: community._id, earnings: amountToWithdraw },
+        { earnings: 0 },
+      );
+      if (claimed === null)
+        return await ctx.reply(ctx.i18n.t('invoice_already_being_paid'));
+
       const user = await User.findById(community.creator_id);
       if (user === null) throw new Error('user was not found');
       logger.debug(`Creating pending payment for community ${community.id}`);
       const pp = new PendingPayment({
-        amount: community.earnings,
+        amount: amountToWithdraw,
         payment_request: lnInvoice,
         user_id: user.id,
         community_id: community._id,

--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -270,10 +270,22 @@ export const attemptCommunitiesPendingPayments = async (
           );
         }
 
-        if (
+        const attemptsExhausted =
           process.env.PAYMENT_ATTEMPTS !== undefined &&
-          pending.attempts >= parseInt(process.env.PAYMENT_ATTEMPTS)
-        ) {
+          pending.attempts >= parseInt(process.env.PAYMENT_ATTEMPTS);
+
+        // SECURITY/accounting: the earnings were atomically claimed (zeroed)
+        // when this withdrawal was scheduled. If the payout has now failed
+        // permanently (invoice expired or no attempts left) we restore them so
+        // the community can withdraw again without losing funds. Because the
+        // pending payment is then excluded from future runs (is_invoice_expired
+        // or attempts >= PAYMENT_ATTEMPTS), this restore happens exactly once.
+        if (pending.is_invoice_expired || attemptsExhausted) {
+          community.earnings += pending.amount;
+          await community.save();
+        }
+
+        if (attemptsExhausted) {
           await bot.telegram.sendMessage(
             user.tg_id,
             i18nCtx.t('pending_payment_failed_earnings', {

--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -217,22 +217,32 @@ export const attemptCommunitiesPendingPayments = async (
       // If the buyer's invoice is expired we let it know and don't try to pay again
       if (!!payment && payment.is_expired) {
         pending.is_invoice_expired = true;
-        await bot.telegram.sendMessage(
-          user.tg_id,
-          i18nCtx.t('invoice_expired_earnings'),
-          {
-            reply_markup: {
-              inline_keyboard: [
-                [
-                  {
-                    text: i18nCtx.t('withdraw_earnings'),
-                    callback_data: `withdrawEarnings_${pending.community_id}`,
-                  },
+        // Don't let a notification failure abort the run before the earnings
+        // are restored further down; restoring the balance is the critical
+        // step and the pending payment is excluded from future runs once it is
+        // flagged as expired.
+        try {
+          await bot.telegram.sendMessage(
+            user.tg_id,
+            i18nCtx.t('invoice_expired_earnings'),
+            {
+              reply_markup: {
+                inline_keyboard: [
+                  [
+                    {
+                      text: i18nCtx.t('withdraw_earnings'),
+                      callback_data: `withdrawEarnings_${pending.community_id}`,
+                    },
+                  ],
                 ],
-              ],
+              },
             },
-          },
-        );
+          );
+        } catch (error) {
+          logger.error(
+            `Failed to notify user ${user.tg_id} about expired invoice: ${error}`,
+          );
+        }
       }
 
       const community = await Community.findById(pending.community_id);
@@ -241,8 +251,10 @@ export const attemptCommunitiesPendingPayments = async (
         pending.paid = true;
         pending.paid_at = new Date();
 
-        // Reset the community's values
-        community.earnings = 0;
+        // The earnings were already atomically zeroed when this withdrawal was
+        // claimed at scheduling time, so don't reset them again here: doing so
+        // would wipe out any earnings accrued between the claim and this
+        // successful payment.
         community.orders_to_redeem = 0;
         await community.save();
         logger.info(
@@ -281,8 +293,11 @@ export const attemptCommunitiesPendingPayments = async (
         // pending payment is then excluded from future runs (is_invoice_expired
         // or attempts >= PAYMENT_ATTEMPTS), this restore happens exactly once.
         if (pending.is_invoice_expired || attemptsExhausted) {
-          community.earnings += pending.amount;
-          await community.save();
+          // Atomic increment against the current DB value so we don't clobber
+          // earnings accrued since this community document was read above.
+          await Community.findByIdAndUpdate(community._id, {
+            $inc: { earnings: pending.amount },
+          });
         }
 
         if (attemptsExhausted) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lnp2pbot",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lnp2pbot",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@grammyjs/i18n": "^0.5.1",


### PR DESCRIPTION
## Summary

Hardens the community earnings withdrawal flow against a race condition that could allow the same earnings balance to be paid out more than once.

Previously, the withdrawal wizard read `community.earnings`, scheduled a pending payment, and only later relied on bookkeeping to reduce the balance. Because the read and the payout scheduling were not atomic, two withdrawal attempts processed close together could each observe the same non-zero balance and both proceed, resulting in the node paying out the same earnings twice.

## Changes

- **`bot/modules/community/scenes.ts`** — Atomically claim the earnings before scheduling the payout. The community's `earnings` is zeroed with a conditional `findOneAndUpdate` that only matches when the balance still equals the snapshotted amount. Concurrent attempts race on this compare-and-set, so only one wins; the loser aborts with the "already being paid" message. The pending payment is created from the snapshotted amount.
- **`jobs/pending_payments.ts`** — When a community payout fails permanently (invoice expired or payment attempts exhausted), restore the claimed earnings so the creator can withdraw again without losing funds. The restore runs exactly once because the pending payment is excluded from subsequent runs once it is expired or out of attempts.

## Testing

- `npx tsc --noEmit` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added atomic concurrency guard preventing duplicate payouts from simultaneous withdrawal attempts.
  * Improved failed payment handling with proper earnings restoration.
  * Enhanced error messaging for expired or exhausted payment attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->