### PR TITLE
fix: serialize order release under per-order mutex with state recheck

### DIFF
--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -14,6 +14,7 @@ import {
   getUserI18nContext,
   getFee,
   removeLightningPrefix,
+  PerOrderIdMutex,
 } from '../util';
 import * as ordersActions from './ordersActions';
 import * as OrderEvents from './modules/events/orders';
@@ -889,18 +890,39 @@ const release = async (
     if (user.banned) return await messages.bannedUserErrorMessage(ctx, user);
     const order = await validateReleaseOrder(ctx, user, orderId);
     if (!order) return;
-    // We look for a dispute for this order
-    const dispute = await Dispute.findOne({ order_id: order._id });
 
-    if (dispute) {
-      dispute.status = 'RELEASED';
-      await dispute.save();
-    }
+    // SECURITY: serialize the settle under the per-order mutex (the same lock
+    // used by payHoldInvoice and the cancel/expiry jobs) and re-read the order
+    // under the lock. validateReleaseOrder ran without the lock, so the order
+    // may have been canceled, settled or otherwise advanced in between. Only
+    // settle if it is still in a releasable state — this closes the
+    // settle-vs-cancel race over the same hold invoice.
+    await PerOrderIdMutex.instance.runExclusive(String(order._id), async () => {
+      const currentOrder = await Order.findById(order._id);
+      if (currentOrder === null) throw new Error('order was not found');
 
-    if (order.secret === null) {
-      throw new Error('order.secret is null');
-    }
-    await settleHoldInvoice({ secret: order.secret });
+      const releasableStatuses = ['ACTIVE', 'FIAT_SENT', 'DISPUTE'];
+      if (!releasableStatuses.includes(currentOrder.status)) {
+        logger.info(
+          `release: order ${order._id} no longer releasable ` +
+            `(status ${currentOrder.status}), skipping settle`,
+        );
+        return;
+      }
+
+      if (currentOrder.secret === null) {
+        throw new Error('order.secret is null');
+      }
+
+      // We look for a dispute for this order
+      const dispute = await Dispute.findOne({ order_id: currentOrder._id });
+      if (dispute) {
+        dispute.status = 'RELEASED';
+        await dispute.save();
+      }
+
+      await settleHoldInvoice({ secret: currentOrder.secret });
+    });
   } catch (error) {
     logger.error(error);
   }

--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -914,14 +914,17 @@ const release = async (
         throw new Error('order.secret is null');
       }
 
-      // We look for a dispute for this order
+      await settleHoldInvoice({ secret: currentOrder.secret });
+
+      // Only mark the dispute as released once the Lightning settle has
+      // actually completed. Otherwise a failed settle would leave a stale
+      // RELEASED dispute that makes solvers believe the seller already
+      // released (see bot/modules/dispute/actions.ts).
       const dispute = await Dispute.findOne({ order_id: currentOrder._id });
       if (dispute) {
         dispute.status = 'RELEASED';
         await dispute.save();
       }
-
-      await settleHoldInvoice({ secret: currentOrder.secret });
     });
   } catch (error) {
     logger.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lnp2pbot",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lnp2pbot",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@grammyjs/i18n": "^0.5.1",


### PR DESCRIPTION
## Summary

Hardens the order release flow against a race condition that could allow a hold invoice to be settled after the order had already moved on (e.g. been canceled), by serializing the settle under the per-order mutex and re-checking the order state under the lock.

Previously, `validateReleaseOrder` ran without holding any lock, and the settle proceeded based on that earlier read. Between validation and the actual settle, the order could be canceled, settled or otherwise advanced by a concurrent action or background job, leaving room for a release-vs-cancel race over the same hold invoice.

## Changes

- **`bot/commands.ts`** — Wrap the settle in `PerOrderIdMutex.instance.runExclusive(orderId, ...)`, the same per-order lock used by `payHoldInvoice` and the cancel/expiry jobs. Inside the lock, re-read the order and only settle when it is still in a releasable state (`ACTIVE`, `FIAT_SENT`, `DISPUTE`); otherwise log and skip. The dispute status update and the `settleHoldInvoice` call now happen against the order re-read under the lock.

## Testing

- `npx tsc --noEmit` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order settlement reliability with enhanced concurrency safety measures. Order state is now consistently validated during settlement operations, ensuring reliable handling of concurrent requests and preventing potential consistency issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->