### PR TITLE
fix: cancel hold invoice when expiring ACTIVE orders

### DIFF
--- a/jobs/cancel_orders.ts
+++ b/jobs/cancel_orders.ts
@@ -1,6 +1,7 @@
 import { HasTelegram } from '../bot/start';
 import { User, Order } from '../models';
 import { cancelShowHoldInvoice, cancelAddInvoice } from '../bot/commands';
+import { cancelHoldInvoice } from '../ln';
 import * as messages from '../bot/messages';
 import {
   getUserI18nContext,
@@ -116,10 +117,41 @@ const cancelOrders = async (bot: HasTelegram) => {
       ],
     });
     for (const order of expiredOrders) {
-      order.status = 'EXPIRED';
-      await order.save();
-      OrderEvents.orderUpdated(order);
-      logger.info(`Order Id ${order.id} expired!`);
+      await PerOrderIdMutex.instance.runExclusive(
+        String(order._id),
+        async () => {
+          const updatedOrder = await Order.findById(order._id);
+          if (!updatedOrder) return;
+          // Don't stomp an order that advanced after the find above (e.g. a
+          // release/payout currently in flight under the same mutex).
+          if (
+            updatedOrder.status !== 'ACTIVE' &&
+            updatedOrder.status !== 'FIAT_SENT'
+          )
+            return;
+
+          // For ACTIVE orders the buyer never signalled fiat-sent, so it is
+          // safe to cancel the hold invoice and refund the seller instead of
+          // orphaning the hash. check_hold_invoice_expired ignores EXPIRED
+          // orders, so without this the seller's funds would stay locked until
+          // the on-chain CLTV timeout. FIAT_SENT orders are NOT auto-refunded
+          // here (the buyer claims to have paid) and are left for the
+          // dispute/admin flow.
+          if (updatedOrder.status === 'ACTIVE' && updatedOrder.hash) {
+            await cancelHoldInvoice({ hash: updatedOrder.hash });
+          } else if (updatedOrder.status === 'FIAT_SENT' && updatedOrder.hash) {
+            logger.warning(
+              `Order Id ${updatedOrder.id} expired in FIAT_SENT with an open ` +
+                `hold invoice; leaving it for dispute/admin handling`,
+            );
+          }
+
+          updatedOrder.status = 'EXPIRED';
+          await updatedOrder.save();
+          OrderEvents.orderUpdated(updatedOrder);
+          logger.info(`Order Id ${updatedOrder.id} expired!`);
+        },
+      );
     }
   } catch (error) {
     logger.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lnp2pbot",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lnp2pbot",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@grammyjs/i18n": "^0.5.1",


### PR DESCRIPTION
## Summary

Ensures that when the cancel-orders job expires an `ACTIVE` order, the associated Lightning hold invoice is canceled so the seller's locked funds are refunded promptly, instead of being orphaned until the on-chain CLTV timeout. The expiry transition is also serialized under the per-order mutex with a state re-check to avoid racing concurrent flows.

Previously, the job marked expired orders as `EXPIRED` without canceling the hold invoice. Because the expired-hold-invoice check ignores `EXPIRED` orders, the seller's funds remained locked until the on-chain timeout.

## Changes

- **`jobs/cancel_orders.ts`** — Run the expiry transition inside `PerOrderIdMutex.instance.runExclusive(orderId, ...)` and re-read the order under the lock so the job does not stomp an order that advanced concurrently (e.g. a release/payout in flight under the same lock). Only `ACTIVE` and `FIAT_SENT` orders are expired:
  - `ACTIVE` — the buyer never signalled fiat-sent, so cancel the hold invoice (refund the seller) before marking the order `EXPIRED`.
  - `FIAT_SENT` — the buyer claims to have paid; the hold invoice is left open and the case is logged for the dispute/admin flow rather than auto-refunded.

## Testing

- `npx tsc --noEmit` passes.
- `prettier --check` and `eslint` pass.
