### PR TITLE
security: patch runtime dependency vulnerabilities (mongoose, grpc-js, bn.js)

### DIFF
--- a/models/community.ts
+++ b/models/community.ts
@@ -41,7 +41,7 @@ const usernameIdSchema = new Schema<IUsernameId>({
   username: { type: String, required: true, trim: true },
 });
 
-export interface ICommunity extends Document {
+export interface ICommunity extends Document<string> {
   _id: string;
   name: string;
   creator_id: string;

--- a/models/order.ts
+++ b/models/order.ts
@@ -1,6 +1,6 @@
 import mongoose, { Document, Schema } from 'mongoose';
 
-export interface IOrder extends Document {
+export interface IOrder extends Document<string> {
   _id: string;
   description?: string;
   amount: number;

--- a/models/user.ts
+++ b/models/user.ts
@@ -5,7 +5,7 @@ interface UserReview {
   reviewed_at: Date;
 }
 
-export interface UserDocument extends Document {
+export interface UserDocument extends Document<string> {
   _id: string;
   tg_id: string;
   username?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "dotenv": "^10.0.0",
         "invoices": "2.0.6",
         "lightning": "10.25.0",
-        "mongoose": "^8.17.1",
+        "mongoose": "^8.24.0",
         "node-schedule": "^2.0.0",
         "nostr-tools": "^2.5.2",
         "qrcode": "^1.5.0",
@@ -152,16 +152,34 @@
       "integrity": "sha512-xBkH/ATJsuv5JgVYX9yQM9DNg75Qqjw+gh82lVsBn4j+d0DkxxC+kuy6WFoB96Cb6oifQfaBJL8CTikdYG4v0A=="
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
-      "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
         "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -331,9 +349,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
-      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -1332,9 +1350,10 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -4214,11 +4233,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/lightning/node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-    },
     "node_modules/lightning/node_modules/bolt07": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/bolt07/-/bolt07-1.9.4.tgz",
@@ -4722,14 +4736,14 @@
       "dev": true
     },
     "node_modules/mongodb": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
-      "integrity": "sha512-fO5ttN9VC8P0F5fqtQmclAkgXZxbIkYRTUi1j8JO6IYwvamkhtYDilJr35jOPELR49zqCJgXZWwCtW7B+TM8vQ==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
+        "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.0"
+        "mongodb-connection-string-url": "^3.0.2"
       },
       "engines": {
         "node": ">=16.20.1"
@@ -4740,7 +4754,7 @@
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
+        "snappy": "^7.3.2",
         "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
@@ -4778,14 +4792,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.17.1.tgz",
-      "integrity": "sha512-aodS4cacux5caoxB5ErEwRmrafIUsVRJxHnvP7URnSUnTenr32j1qBVV+KjYxryyLSisQkxglAFF69TNLeZTLg==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.0.tgz",
+      "integrity": "sha512-EEZwOibDPZ5uZN3bFapfnRskEbdljAf6sP9ln6u+P4e5IfkOAh6Tqw2g8/Tag++KHOAJ095WXT/c0uqRq4Vckg==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
         "kareem": "2.6.3",
-        "mongodb": "~6.18.0",
+        "mongodb": "~6.20.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -5597,12 +5611,6 @@
       "engines": {
         "node": ">=8.0.0"
       }
-    },
-    "node_modules/psbt/node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-      "license": "MIT"
     },
     "node_modules/psbt/node_modules/bs58": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^10.0.0",
     "invoices": "2.0.6",
     "lightning": "10.25.0",
-    "mongoose": "^8.17.1",
+    "mongoose": "^8.24.0",
     "node-schedule": "^2.0.0",
     "nostr-tools": "^2.5.2",
     "qrcode": "^1.5.0",
@@ -36,6 +36,10 @@
     "telegraf": "4.8.0",
     "websocket-polyfill": "0.0.3",
     "winston": "^3.7.2"
+  },
+  "overrides": {
+    "@grpc/grpc-js": "^1.13.5",
+    "bn.js": "^5.2.3"
   },
   "keywords": [
     "lightning",


### PR DESCRIPTION
## Qué hace

Cierra las alertas de Dependabot de **scope runtime (producción)** que son seguras de aplicar:

| Paquete | Antes | Ahora | Alerta | Sev |
|---------|-------|-------|--------|-----|
| `mongoose` | 8.17.1 | **8.24.0** | GHSA-wpg9-53fq-2r8h ($nor NoSQL injection) | high |
| `@grpc/grpc-js` | 1.13.1 | **1.14.4** (override `^1.13.5`) | GHSA-5375-pq7m-f5r2 / GHSA-99f4-grh7-6pcq (DoS crash) | high |
| `bn.js` | 5.2.0/5.2.1 | **5.2.3** (override) | GHSA-378v-28hj-76wf (infinite-loop DoS) | medium |

`@grpc/grpc-js` y `bn.js` son transitivas (vía `lightning` / `invoices`), por eso se fijan con `overrides`.

## Cambio de tipos por mongoose

Mongoose 8.22+ endureció el genérico de `Document._id`. Las tres interfaces que declaran `_id: string` (`IOrder`, `ICommunity`, `UserDocument`) ahora extienden `Document<string>` para mantener la compatibilidad. Sin esto el build de TypeScript falla.

## Fuera de alcance (a tratar aparte)

- **valibot** (ReDoS, high, transitiva vía `ecpair`→`lightning`): requiere subir `lightning` (10.25→10.27.x). La ruta vulnerable (`EMOJI_REGEX`) no es alcanzable desde esta app, así que se difiere a un PR propio con pruebas de la integración LND.
- **28 alertas dev-only** (`axios` 0.x, `express`, `body-parser`, `qs`, `serialize-javascript`, `glob`, etc.): provienen de `telegram-test-api` y `mocha`; no se despliegan a producción. Se limpiarán subiendo esas herramientas en un PR aparte.

## Verificación

- `npm ci` ✓ (lockfile en sync)
- `npx tsc` ✓
- `npm run lint` ✓
- `npm test` ✓ — 133 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database driver dependency to a newer version and resolved dependency version constraints for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->