### PR TITLE
feat: add configurable user requirements for community creation

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -86,6 +86,11 @@ NOSTR_SK=''
 
 # Enable community creation via the /community command (default: false, opt-in per instance)
 COMMUNITY_CREATION_ENABLED=false
+# Minimum requirements to create a community (leave unset to disable the restriction)
+# COMMUNITY_CREATION_MIN_ORDERS=100
+# COMMUNITY_CREATION_MIN_VOLUME=10000000
+# COMMUNITY_CREATION_MIN_DAYS_USING_BOT=365
+# COMMUNITY_CREATION_MIN_REPUTATION=4.8
 
 # Number of currencies allowed in a community
 COMMUNITY_CURRENCIES=20

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -21,7 +21,7 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
       const parseOptionalNumber = (raw: string | undefined): number | null => {
         if (raw == null || raw.trim() === '') return null;
         const n = Number(raw);
-        return Number.isFinite(n) ? n : null;
+        return Number.isFinite(n) && n >= 0 ? n : null;
       };
 
       const thresholds = {

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -1,4 +1,5 @@
 import { Telegraf } from 'telegraf';
+import { logger } from '../../../logger';
 import { userMiddleware, superAdminMiddleware } from '../../middleware/user';
 import * as actions from './actions';
 import * as commands from './commands';
@@ -15,6 +16,38 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('mycomms', userMiddleware, commands.myComms);
   if (process.env.COMMUNITY_CREATION_ENABLED === 'true') {
     bot.command('community', userMiddleware, async ctx => {
+      const { user } = ctx;
+
+      const minOrders = parseInt(
+        process.env.COMMUNITY_CREATION_MIN_ORDERS || '',
+      );
+      const minVolume = parseInt(
+        process.env.COMMUNITY_CREATION_MIN_VOLUME || '',
+      );
+      const minDays = parseInt(
+        process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT || '',
+      );
+      const minReputation = parseFloat(
+        process.env.COMMUNITY_CREATION_MIN_REPUTATION || '',
+      );
+
+      const daysUsing = Math.floor(
+        (Date.now() - new Date(user.created_at).getTime()) / 86400000,
+      );
+
+      const meetsRequirements =
+        (isNaN(minOrders) || user.trades_completed >= minOrders) &&
+        (isNaN(minVolume) || user.volume_traded >= minVolume) &&
+        (isNaN(minDays) || daysUsing >= minDays) &&
+        (isNaN(minReputation) || user.total_rating >= minReputation);
+
+      if (!meetsRequirements) {
+        logger.error(
+          `User ${user.tg_id} tried to create a community but does not meet the requirements - orders: ${user.trades_completed}, volume: ${user.volume_traded}, days: ${daysUsing}, reputation: ${user.total_rating}`,
+        );
+        return ctx.reply(ctx.i18n.t('community_creation_requirements_not_met'));
+      }
+
       await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', {
         bot,
         user: ctx.user,

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -18,28 +18,57 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
     bot.command('community', userMiddleware, async ctx => {
       const { user } = ctx;
 
-      const minOrders = parseInt(
-        process.env.COMMUNITY_CREATION_MIN_ORDERS || '',
-      );
-      const minVolume = parseInt(
-        process.env.COMMUNITY_CREATION_MIN_VOLUME || '',
-      );
-      const minDays = parseInt(
-        process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT || '',
-      );
-      const minReputation = parseFloat(
-        process.env.COMMUNITY_CREATION_MIN_REPUTATION || '',
-      );
+      const parseOptionalNumber = (raw: string | undefined): number | null => {
+        if (raw == null || raw.trim() === '') return null;
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : null;
+      };
+
+      const thresholds = {
+        COMMUNITY_CREATION_MIN_ORDERS: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_ORDERS,
+        ),
+        COMMUNITY_CREATION_MIN_VOLUME: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_VOLUME,
+        ),
+        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT,
+        ),
+        COMMUNITY_CREATION_MIN_REPUTATION: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_REPUTATION,
+        ),
+      };
+
+      const invalidEnvVars = Object.entries(thresholds)
+        .filter(
+          ([key, val]) =>
+            val === null && (process.env[key] ?? '').trim() !== '',
+        )
+        .map(([key]) => key);
+
+      if (invalidEnvVars.length > 0) {
+        logger.error(
+          `Invalid COMMUNITY_CREATION_* threshold configuration: ${invalidEnvVars.join(', ')}`,
+        );
+        return ctx.reply(ctx.i18n.t('generic_error'));
+      }
+
+      const {
+        COMMUNITY_CREATION_MIN_ORDERS: minOrders,
+        COMMUNITY_CREATION_MIN_VOLUME: minVolume,
+        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: minDays,
+        COMMUNITY_CREATION_MIN_REPUTATION: minReputation,
+      } = thresholds;
 
       const daysUsing = Math.floor(
         (Date.now() - new Date(user.created_at).getTime()) / 86400000,
       );
 
       const meetsRequirements =
-        (isNaN(minOrders) || user.trades_completed >= minOrders) &&
-        (isNaN(minVolume) || user.volume_traded >= minVolume) &&
-        (isNaN(minDays) || daysUsing >= minDays) &&
-        (isNaN(minReputation) || user.total_rating >= minReputation);
+        (minOrders === null || user.trades_completed >= minOrders) &&
+        (minVolume === null || user.volume_traded >= minVolume) &&
+        (minDays === null || daysUsing >= minDays) &&
+        (minReputation === null || user.total_rating >= minReputation);
 
       if (!meetsRequirements) {
         logger.error(

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -722,6 +722,7 @@ payment_methods_reset: "Zahlungsmethoden entfernt. Benutzer können jetzt belieb
 payment_methods_wizard_commands: "/reset — alle Zahlungsmethoden entfernen und Standardverhalten wiederherstellen\n/exit — ohne Speichern beenden"
 community_disabled_by_admin: Ein Administrator hat deine Community ${communityName} deaktiviert
 community_enabled_by_admin: Ein Administrator hat deine Community ${communityName} wieder aktiviert
+community_creation_requirements_not_met: "Du erfüllst nicht die Anforderungen zur Erstellung einer Community"
 community_already_disabled: Diese Community ist bereits deaktiviert
 community_already_enabled: Diese Community ist bereits aktiviert
 ambiguous_community_input: Mehrere Communities stimmen mit diesem Benutzernamen überein, bitte verwende stattdessen die Community-ID

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -728,6 +728,7 @@ payment_methods_reset: "Payment methods removed. Users can now enter any payment
 payment_methods_wizard_commands: "/reset — remove all payment methods and restore default behavior\n/exit — exit without saving"
 community_disabled_by_admin: An administrator has disabled your community ${communityName}
 community_enabled_by_admin: An administrator has re-enabled your community ${communityName}
+community_creation_requirements_not_met: "You don't meet the requirements to create a community"
 community_already_disabled: This community is already disabled
 community_already_enabled: This community is already enabled
 ambiguous_community_input: Multiple communities match that username, please use the community ID instead

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -725,6 +725,7 @@ payment_methods_reset: "Métodos de pago eliminados. Los usuarios ahora pueden i
 payment_methods_wizard_commands: "/reset — eliminar todos los métodos de pago y restaurar el comportamiento predeterminado\n/exit — salir sin guardar"
 community_disabled_by_admin: Un administrador ha deshabilitado tu comunidad ${communityName}
 community_enabled_by_admin: Un administrador ha reactivado tu comunidad ${communityName}
+community_creation_requirements_not_met: "No cumples con los requisitos para crear una comunidad"
 community_already_disabled: Esta comunidad ya está deshabilitada
 community_already_enabled: Esta comunidad ya está habilitada
 ambiguous_community_input: Varias comunidades coinciden con ese nombre de usuario, por favor usa el ID de la comunidad

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -821,6 +821,7 @@ payment_methods_reset: "روش‌های پرداخت حذف شدند. کاربر
 payment_methods_wizard_commands: "/reset — حذف همه روش‌های پرداخت و بازگرداندن رفتار پیش‌فرض\n/exit — خروج بدون ذخیره"
 community_disabled_by_admin: یک مدیر جامعه ${communityName} شما را غیرفعال کرد
 community_enabled_by_admin: یک مدیر جامعه ${communityName} شما را دوباره فعال کرد
+community_creation_requirements_not_met: "شما شرایط لازم برای ایجاد جامعه را ندارید"
 community_already_disabled: این جامعه از قبل غیرفعال است
 community_already_enabled: این جامعه از قبل فعال است
 ambiguous_community_input: چندین جامعه با این نام کاربری مطابقت دارند، لطفاً از شناسه جامعه استفاده کنید

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -721,6 +721,7 @@ payment_methods_reset: "Méthodes de paiement supprimées. Les utilisateurs peuv
 payment_methods_wizard_commands: "/reset — supprimer toutes les méthodes de paiement et restaurer le comportement par défaut\n/exit — quitter sans enregistrer"
 community_disabled_by_admin: Un administrateur a désactivé votre communauté ${communityName}
 community_enabled_by_admin: Un administrateur a réactivé votre communauté ${communityName}
+community_creation_requirements_not_met: "Vous ne remplissez pas les conditions pour créer une communauté"
 community_already_disabled: Cette communauté est déjà désactivée
 community_already_enabled: Cette communauté est déjà activée
 ambiguous_community_input: Plusieurs communautés correspondent à ce nom d'utilisateur, veuillez utiliser l'ID de la communauté à la place

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -719,6 +719,7 @@ payment_methods_reset: "Metodi di pagamento rimossi. Gli utenti possono ora inse
 payment_methods_wizard_commands: "/reset — rimuovere tutti i metodi di pagamento e ripristinare il comportamento predefinito\n/exit — uscire senza salvare"
 community_disabled_by_admin: Un amministratore ha disabilitato la tua comunità ${communityName}
 community_enabled_by_admin: Un amministratore ha riabilitato la tua comunità ${communityName}
+community_creation_requirements_not_met: "Non soddisfi i requisiti per creare una comunità"
 community_already_disabled: Questa comunità è già disabilitata
 community_already_enabled: Questa comunità è già abilitata
 ambiguous_community_input: Più comunità corrispondono a quel nome utente, usa invece l'ID della comunità

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -719,6 +719,7 @@ payment_methods_reset: "결제 방법이 삭제되었습니다. 이제 사용자
 payment_methods_wizard_commands: "/reset — 모든 결제 방법을 삭제하고 기본 동작을 복원합니다\n/exit — 저장하지 않고 종료"
 community_disabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 비활성화했습니다
 community_enabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 다시 활성화했습니다
+community_creation_requirements_not_met: "커뮤니티를 생성하기 위한 요건을 충족하지 못했습니다"
 community_already_disabled: 이 커뮤니티는 이미 비활성화되어 있습니다
 community_already_enabled: 이 커뮤니티는 이미 활성화되어 있습니다
 ambiguous_community_input: 해당 사용자 이름과 일치하는 커뮤니티가 여러 개 있습니다. 커뮤니티 ID를 사용해 주세요

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -721,6 +721,7 @@ payment_methods_reset: "Métodos de pagamento removidos. Os usuários agora pode
 payment_methods_wizard_commands: "/reset — remover todos os métodos de pagamento e restaurar o comportamento padrão\n/exit — sair sem salvar"
 community_disabled_by_admin: Um administrador desativou sua comunidade ${communityName}
 community_enabled_by_admin: Um administrador reativou sua comunidade ${communityName}
+community_creation_requirements_not_met: "Você não atende aos requisitos para criar uma comunidade"
 community_already_disabled: Esta comunidade já está desativada
 community_already_enabled: Esta comunidade já está ativada
 ambiguous_community_input: Várias comunidades correspondem a esse nome de usuário, por favor use o ID da comunidade

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -722,6 +722,7 @@ payment_methods_reset: "Способы оплаты удалены. Пользо
 payment_methods_wizard_commands: "/reset — удалить все способы оплаты и восстановить поведение по умолчанию\n/exit — выйти без сохранения"
 community_disabled_by_admin: Администратор отключил ваше сообщество ${communityName}
 community_enabled_by_admin: Администратор повторно включил ваше сообщество ${communityName}
+community_creation_requirements_not_met: "Вы не соответствуете требованиям для создания сообщества"
 community_already_disabled: Это сообщество уже отключено
 community_already_enabled: Это сообщество уже включено
 ambiguous_community_input: Несколько сообществ соответствуют этому имени пользователя, пожалуйста, используйте ID сообщества

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -718,6 +718,7 @@ payment_methods_reset: "Способи оплати видалено. Корис
 payment_methods_wizard_commands: "/reset — видалити всі способи оплати та відновити поведінку за замовчуванням\n/exit — вийти без збереження"
 community_disabled_by_admin: Адміністратор вимкнув вашу спільноту ${communityName}
 community_enabled_by_admin: Адміністратор повторно увімкнув вашу спільноту ${communityName}
+community_creation_requirements_not_met: "Ви не відповідаєте вимогам для створення спільноти"
 community_already_disabled: Ця спільнота вже вимкнена
 community_already_enabled: Ця спільнота вже увімкнена
 ambiguous_community_input: Кілька спільнот відповідають цьому імені користувача, будь ласка, використовуйте ID спільноти


### PR DESCRIPTION
## Summary
  
  - Add environment-based minimum requirements to the `/community` command so only users who meet configurable thresholds can create a community
  - If any requirement is not met, the bot replies with a short error message and exits — no scene is entered
  - If an env var is not set, that restriction is simply not applied

  ## Changes

  - `bot/modules/community/index.ts` — validation logic before entering `COMMUNITY_WIZARD_SCENE_ID`
  - `.env-sample` — four new commented-out variables with suggested default values
  - `locales/*.yaml` — added `community_creation_requirements_not_met` key in all 10 supported languages

  ## New env vars

  | Variable | Description |
  | --- | --- |
  | `COMMUNITY_CREATION_MIN_ORDERS` | Minimum completed orders |
  | `COMMUNITY_CREATION_MIN_VOLUME` | Minimum sats traded |
  | `COMMUNITY_CREATION_MIN_DAYS_USING_BOT` | Minimum days since first use |
  | `COMMUNITY_CREATION_MIN_REPUTATION` | Minimum reputation score |

  All four are optional. Unset = no restriction for that field.

  ## Suggested production values

  ```env
  COMMUNITY_CREATION_MIN_ORDERS=100
  COMMUNITY_CREATION_MIN_VOLUME=10000000
  COMMUNITY_CREATION_MIN_DAYS_USING_BOT=365
  COMMUNITY_CREATION_MIN_REPUTATION=4.8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community creation now enforces configurable minimum requirements based on orders, traded volume, account age, and reputation.
  * When users don’t meet the criteria, community creation is blocked with a clear explanation.

* **Configuration**
  * Added documented (commented) environment keys for minimum requirements, designed to be left unset to disable each restriction.

* **Localization**
  * Added a new “requirements not met” message to multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->