### PR TITLE
feat: add configurable user requirements for community creation

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -87,6 +87,7 @@ NOSTR_SK=''
 # Enable community creation via the /community command (default: false, opt-in per instance)
 COMMUNITY_CREATION_ENABLED=false
 # Minimum requirements to create a community (leave unset to disable the restriction)
+# Note: It is recommended to combine MIN_REPUTATION with MIN_ORDERS to avoid gaming the system.
 # COMMUNITY_CREATION_MIN_ORDERS=100
 # COMMUNITY_CREATION_MIN_VOLUME=10000000
 # COMMUNITY_CREATION_MIN_DAYS_USING_BOT=365

--- a/.env-sample
+++ b/.env-sample
@@ -88,8 +88,9 @@ NOSTR_SK=''
 COMMUNITY_CREATION_ENABLED=false
 # Minimum requirements to create a community (leave unset to disable the restriction)
 # Note: It is recommended to combine MIN_REPUTATION with MIN_ORDERS to avoid gaming the system.
+# MIN_VOLUME is measured in satoshis.
 # COMMUNITY_CREATION_MIN_ORDERS=100
-# COMMUNITY_CREATION_MIN_VOLUME=10000000
+# COMMUNITY_CREATION_MIN_VOLUME_SATS=10000000
 # COMMUNITY_CREATION_MIN_DAYS_USING_BOT=365
 # COMMUNITY_CREATION_MIN_REPUTATION=4.8
 

--- a/.env-sample
+++ b/.env-sample
@@ -86,6 +86,11 @@ NOSTR_SK=''
 
 # Enable community creation via the /community command (default: false, opt-in per instance)
 COMMUNITY_CREATION_ENABLED=false
+# Minimum requirements to create a community (leave unset to disable the restriction)
+# COMMUNITY_CREATION_MIN_ORDERS=100
+# COMMUNITY_CREATION_MIN_VOLUME=10000000
+# COMMUNITY_CREATION_MIN_DAYS_USING_BOT=365
+# COMMUNITY_CREATION_MIN_REPUTATION=4.8
 
 # Number of currencies allowed in a community
 COMMUNITY_CURRENCIES=20

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -21,7 +21,7 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
       const parseOptionalNumber = (raw: string | undefined): number | null => {
         if (raw == null || raw.trim() === '') return null;
         const n = Number(raw);
-        return Number.isFinite(n) ? n : null;
+        return Number.isFinite(n) && n >= 0 ? n : null;
       };
 
       const thresholds = {

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -1,4 +1,5 @@
 import { Telegraf } from 'telegraf';
+import { logger } from '../../../logger';
 import { userMiddleware, superAdminMiddleware } from '../../middleware/user';
 import * as actions from './actions';
 import * as commands from './commands';
@@ -15,6 +16,38 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('mycomms', userMiddleware, commands.myComms);
   if (process.env.COMMUNITY_CREATION_ENABLED === 'true') {
     bot.command('community', userMiddleware, async ctx => {
+      const { user } = ctx;
+
+      const minOrders = parseInt(
+        process.env.COMMUNITY_CREATION_MIN_ORDERS || '',
+      );
+      const minVolume = parseInt(
+        process.env.COMMUNITY_CREATION_MIN_VOLUME || '',
+      );
+      const minDays = parseInt(
+        process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT || '',
+      );
+      const minReputation = parseFloat(
+        process.env.COMMUNITY_CREATION_MIN_REPUTATION || '',
+      );
+
+      const daysUsing = Math.floor(
+        (Date.now() - new Date(user.created_at).getTime()) / 86400000,
+      );
+
+      const meetsRequirements =
+        (isNaN(minOrders) || user.trades_completed >= minOrders) &&
+        (isNaN(minVolume) || user.volume_traded >= minVolume) &&
+        (isNaN(minDays) || daysUsing >= minDays) &&
+        (isNaN(minReputation) || user.total_rating >= minReputation);
+
+      if (!meetsRequirements) {
+        logger.error(
+          `User ${user.tg_id} tried to create a community but does not meet the requirements - orders: ${user.trades_completed}, volume: ${user.volume_traded}, days: ${daysUsing}, reputation: ${user.total_rating}`,
+        );
+        return ctx.reply(ctx.i18n.t('community_creation_requirements_not_met'));
+      }
+
       await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', {
         bot,
         user: ctx.user,

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -18,13 +18,14 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
     bot.command('community', userMiddleware, async ctx => {
       const { user } = ctx;
 
-      const parseOptionalNumber = (raw: string | undefined): number | null => {
-        if (raw == null || raw.trim() === '') return null;
+      const parseOptionalNumber = (raw: string | undefined): { value: number | null, isValid: boolean } => {
+        if (raw == null || raw.trim() === '') return { value: null, isValid: true };
         const n = Number(raw);
-        return Number.isFinite(n) && n >= 0 ? n : null;
+        if (Number.isFinite(n) && n >= 0) return { value: n, isValid: true };
+        return { value: null, isValid: false };
       };
 
-      const thresholds = {
+      const thresholdResults = {
         COMMUNITY_CREATION_MIN_ORDERS: parseOptionalNumber(
           process.env.COMMUNITY_CREATION_MIN_ORDERS,
         ),
@@ -39,11 +40,8 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
         ),
       };
 
-      const invalidEnvVars = Object.entries(thresholds)
-        .filter(
-          ([key, val]) =>
-            val === null && (process.env[key] ?? '').trim() !== '',
-        )
+      const invalidEnvVars = Object.entries(thresholdResults)
+        .filter(([_, res]) => !res.isValid)
         .map(([key]) => key);
 
       if (invalidEnvVars.length > 0) {
@@ -54,11 +52,11 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
       }
 
       const {
-        COMMUNITY_CREATION_MIN_ORDERS: minOrders,
-        COMMUNITY_CREATION_MIN_VOLUME: minVolume,
-        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: minDays,
-        COMMUNITY_CREATION_MIN_REPUTATION: minReputation,
-      } = thresholds;
+        COMMUNITY_CREATION_MIN_ORDERS: { value: minOrders },
+        COMMUNITY_CREATION_MIN_VOLUME: { value: minVolume },
+        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: { value: minDays },
+        COMMUNITY_CREATION_MIN_REPUTATION: { value: minReputation },
+      } = thresholdResults;
 
       const daysUsing = Math.floor(
         (Date.now() - new Date(user.created_at).getTime()) / 86400000,

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -18,28 +18,57 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
     bot.command('community', userMiddleware, async ctx => {
       const { user } = ctx;
 
-      const minOrders = parseInt(
-        process.env.COMMUNITY_CREATION_MIN_ORDERS || '',
-      );
-      const minVolume = parseInt(
-        process.env.COMMUNITY_CREATION_MIN_VOLUME || '',
-      );
-      const minDays = parseInt(
-        process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT || '',
-      );
-      const minReputation = parseFloat(
-        process.env.COMMUNITY_CREATION_MIN_REPUTATION || '',
-      );
+      const parseOptionalNumber = (raw: string | undefined): number | null => {
+        if (raw == null || raw.trim() === '') return null;
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : null;
+      };
+
+      const thresholds = {
+        COMMUNITY_CREATION_MIN_ORDERS: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_ORDERS,
+        ),
+        COMMUNITY_CREATION_MIN_VOLUME: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_VOLUME,
+        ),
+        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT,
+        ),
+        COMMUNITY_CREATION_MIN_REPUTATION: parseOptionalNumber(
+          process.env.COMMUNITY_CREATION_MIN_REPUTATION,
+        ),
+      };
+
+      const invalidEnvVars = Object.entries(thresholds)
+        .filter(
+          ([key, val]) =>
+            val === null && (process.env[key] ?? '').trim() !== '',
+        )
+        .map(([key]) => key);
+
+      if (invalidEnvVars.length > 0) {
+        logger.error(
+          `Invalid COMMUNITY_CREATION_* threshold configuration: ${invalidEnvVars.join(', ')}`,
+        );
+        return ctx.reply(ctx.i18n.t('generic_error'));
+      }
+
+      const {
+        COMMUNITY_CREATION_MIN_ORDERS: minOrders,
+        COMMUNITY_CREATION_MIN_VOLUME: minVolume,
+        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: minDays,
+        COMMUNITY_CREATION_MIN_REPUTATION: minReputation,
+      } = thresholds;
 
       const daysUsing = Math.floor(
         (Date.now() - new Date(user.created_at).getTime()) / 86400000,
       );
 
       const meetsRequirements =
-        (isNaN(minOrders) || user.trades_completed >= minOrders) &&
-        (isNaN(minVolume) || user.volume_traded >= minVolume) &&
-        (isNaN(minDays) || daysUsing >= minDays) &&
-        (isNaN(minReputation) || user.total_rating >= minReputation);
+        (minOrders === null || user.trades_completed >= minOrders) &&
+        (minVolume === null || user.volume_traded >= minVolume) &&
+        (minDays === null || daysUsing >= minDays) &&
+        (minReputation === null || user.total_rating >= minReputation);
 
       if (!meetsRequirements) {
         logger.error(

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -10,87 +10,16 @@ import {
 } from './messages';
 import { CommunityContext } from './communityContext';
 import * as Scenes from './scenes';
-
-interface ParsedThresholds {
-  minOrders: number | null;
-  minVolume: number | null;
-  minDays: number | null;
-  minReputation: number | null;
-  invalidEnvVars: string[];
-}
-
-interface UserMetrics {
-  tg_id: string;
-  trades_completed: number;
-  volume_traded: number;
-  total_rating: number;
-  created_at: Date | string;
-}
-
-const parseOptionalNumber = (
-  raw: string | undefined,
-): { value: number | null; isValid: boolean } => {
-  if (raw == null || raw.trim() === '') return { value: null, isValid: true };
-  const n = Number(raw);
-  if (Number.isFinite(n) && n >= 0) return { value: n, isValid: true };
-  return { value: null, isValid: false };
-};
-
-const getCommunityThresholds = (): ParsedThresholds => {
-  const thresholdResults = {
-    COMMUNITY_CREATION_MIN_ORDERS: parseOptionalNumber(
-      process.env.COMMUNITY_CREATION_MIN_ORDERS,
-    ),
-    COMMUNITY_CREATION_MIN_VOLUME: parseOptionalNumber(
-      process.env.COMMUNITY_CREATION_MIN_VOLUME,
-    ),
-    COMMUNITY_CREATION_MIN_DAYS_USING_BOT: parseOptionalNumber(
-      process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT,
-    ),
-    COMMUNITY_CREATION_MIN_REPUTATION: parseOptionalNumber(
-      process.env.COMMUNITY_CREATION_MIN_REPUTATION,
-    ),
-  };
-
-  const invalidEnvVars = Object.entries(thresholdResults)
-    .filter(([_, res]) => !res.isValid)
-    .map(([key]) => key);
-
-  return {
-    minOrders: thresholdResults.COMMUNITY_CREATION_MIN_ORDERS.value,
-    minVolume: thresholdResults.COMMUNITY_CREATION_MIN_VOLUME.value,
-    minDays: thresholdResults.COMMUNITY_CREATION_MIN_DAYS_USING_BOT.value,
-    minReputation: thresholdResults.COMMUNITY_CREATION_MIN_REPUTATION.value,
-    invalidEnvVars,
-  };
-};
-
-const meetsCommunityCreationRequirements = (
-  user: UserMetrics,
-  thresholds: Omit<ParsedThresholds, 'invalidEnvVars'>,
-): { meets: boolean; daysUsing: number | null; hasInvalidDate: boolean } => {
-  const createdAtTime = new Date(user.created_at).getTime();
-  if (!Number.isFinite(createdAtTime)) {
-    return { meets: false, daysUsing: null, hasInvalidDate: true };
-  }
-
-  const daysUsing = Math.floor((Date.now() - createdAtTime) / 86400000);
-  const { minOrders, minVolume, minDays, minReputation } = thresholds;
-
-  const meets =
-    (minOrders === null || user.trades_completed >= minOrders) &&
-    (minVolume === null || user.volume_traded >= minVolume) &&
-    (minDays === null || daysUsing >= minDays) &&
-    (minReputation === null || user.total_rating >= minReputation);
-
-  return { meets, daysUsing, hasInvalidDate: false };
-};
+import {
+  getCommunityThresholds,
+  meetsCommunityCreationRequirements,
+} from './requirements';
 
 export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('mycomm', userMiddleware, commands.communityAdmin);
   bot.command('mycomms', userMiddleware, commands.myComms);
   if (process.env.COMMUNITY_CREATION_ENABLED === 'true') {
-    // Parsing of this values only happens once, they are not reparsed every time an user wants to create a new community
+    // Parsing of these values only happens once, they are not reparsed every time a user wants to create a new community
     const { invalidEnvVars, minOrders, minVolume, minDays, minReputation } =
       getCommunityThresholds();
 
@@ -99,18 +28,27 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
 
       if (invalidEnvVars.length > 0) {
         logger.error(
-          `Invalid COMMUNITY_CREATION_* threshold configuration: ${invalidEnvVars.join(', ')}`,
+          `Community creation is failing due to a misconfiguration in initialization time: ${invalidEnvVars.join(', ')}`,
         );
         return ctx.reply(ctx.i18n.t('generic_error'));
       }
 
       const { meets, daysUsing, hasInvalidDate } =
-        meetsCommunityCreationRequirements(user, {
-          minOrders,
-          minVolume,
-          minDays,
-          minReputation,
-        });
+        meetsCommunityCreationRequirements(
+          {
+            tg_id: user.tg_id,
+            trades_completed: user.trades_completed,
+            volume_traded: user.volume_traded,
+            total_rating: user.total_rating,
+            created_at: user.created_at,
+          },
+          {
+            minOrders,
+            minVolume,
+            minDays,
+            minReputation,
+          },
+        );
 
       if (hasInvalidDate) {
         logger.error(
@@ -124,18 +62,44 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
           `User ${user.tg_id} tried to create a community but does not meet the requirements - orders: ${user.trades_completed}, volume: ${user.volume_traded}, days: ${daysUsing}, reputation: ${user.total_rating}`,
         );
 
-        return ctx.reply(
-          ctx.i18n.t('community_creation_requirements_not_met', {
-            userOrders: user.trades_completed,
-            requiredOrders: minOrders ?? '-',
-            userVolume: user.volume_traded,
-            requiredVolume: minVolume ?? '-',
-            userDays: daysUsing,
-            requiredDays: minDays ?? '-',
-            userRep: user.total_rating,
-            requiredRep: minReputation ?? '-',
-          }),
-        );
+        // Build the message dynamically based on active thresholds
+        const lines = [
+          ctx.i18n.t('community_creation_requirements_not_met_header'),
+        ];
+        if (minOrders !== null) {
+          lines.push(
+            ctx.i18n.t('community_creation_requirements_not_met_orders', {
+              userOrders: user.trades_completed,
+              requiredOrders: minOrders,
+            }),
+          );
+        }
+        if (minVolume !== null) {
+          lines.push(
+            ctx.i18n.t('community_creation_requirements_not_met_volume', {
+              userVolume: user.volume_traded,
+              requiredVolume: minVolume,
+            }),
+          );
+        }
+        if (minDays !== null) {
+          lines.push(
+            ctx.i18n.t('community_creation_requirements_not_met_days', {
+              userDays: daysUsing,
+              requiredDays: minDays,
+            }),
+          );
+        }
+        if (minReputation !== null) {
+          lines.push(
+            ctx.i18n.t('community_creation_requirements_not_met_rep', {
+              userRep: user.total_rating.toFixed(2),
+              requiredRep: minReputation,
+            }),
+          );
+        }
+
+        return ctx.reply(lines.join('\n'));
       }
 
       await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', {

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -18,8 +18,11 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
     bot.command('community', userMiddleware, async ctx => {
       const { user } = ctx;
 
-      const parseOptionalNumber = (raw: string | undefined): { value: number | null, isValid: boolean } => {
-        if (raw == null || raw.trim() === '') return { value: null, isValid: true };
+      const parseOptionalNumber = (
+        raw: string | undefined,
+      ): { value: number | null; isValid: boolean } => {
+        if (raw == null || raw.trim() === '')
+          return { value: null, isValid: true };
         const n = Number(raw);
         if (Number.isFinite(n) && n >= 0) return { value: n, isValid: true };
         return { value: null, isValid: false };

--- a/bot/modules/community/index.ts
+++ b/bot/modules/community/index.ts
@@ -11,41 +11,91 @@ import {
 import { CommunityContext } from './communityContext';
 import * as Scenes from './scenes';
 
+interface ParsedThresholds {
+  minOrders: number | null;
+  minVolume: number | null;
+  minDays: number | null;
+  minReputation: number | null;
+  invalidEnvVars: string[];
+}
+
+interface UserMetrics {
+  tg_id: string;
+  trades_completed: number;
+  volume_traded: number;
+  total_rating: number;
+  created_at: Date | string;
+}
+
+const parseOptionalNumber = (
+  raw: string | undefined,
+): { value: number | null; isValid: boolean } => {
+  if (raw == null || raw.trim() === '') return { value: null, isValid: true };
+  const n = Number(raw);
+  if (Number.isFinite(n) && n >= 0) return { value: n, isValid: true };
+  return { value: null, isValid: false };
+};
+
+const getCommunityThresholds = (): ParsedThresholds => {
+  const thresholdResults = {
+    COMMUNITY_CREATION_MIN_ORDERS: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_ORDERS,
+    ),
+    COMMUNITY_CREATION_MIN_VOLUME: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_VOLUME,
+    ),
+    COMMUNITY_CREATION_MIN_DAYS_USING_BOT: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT,
+    ),
+    COMMUNITY_CREATION_MIN_REPUTATION: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_REPUTATION,
+    ),
+  };
+
+  const invalidEnvVars = Object.entries(thresholdResults)
+    .filter(([_, res]) => !res.isValid)
+    .map(([key]) => key);
+
+  return {
+    minOrders: thresholdResults.COMMUNITY_CREATION_MIN_ORDERS.value,
+    minVolume: thresholdResults.COMMUNITY_CREATION_MIN_VOLUME.value,
+    minDays: thresholdResults.COMMUNITY_CREATION_MIN_DAYS_USING_BOT.value,
+    minReputation: thresholdResults.COMMUNITY_CREATION_MIN_REPUTATION.value,
+    invalidEnvVars,
+  };
+};
+
+const meetsCommunityCreationRequirements = (
+  user: UserMetrics,
+  thresholds: Omit<ParsedThresholds, 'invalidEnvVars'>,
+): { meets: boolean; daysUsing: number | null; hasInvalidDate: boolean } => {
+  const createdAtTime = new Date(user.created_at).getTime();
+  if (!Number.isFinite(createdAtTime)) {
+    return { meets: false, daysUsing: null, hasInvalidDate: true };
+  }
+
+  const daysUsing = Math.floor((Date.now() - createdAtTime) / 86400000);
+  const { minOrders, minVolume, minDays, minReputation } = thresholds;
+
+  const meets =
+    (minOrders === null || user.trades_completed >= minOrders) &&
+    (minVolume === null || user.volume_traded >= minVolume) &&
+    (minDays === null || daysUsing >= minDays) &&
+    (minReputation === null || user.total_rating >= minReputation);
+
+  return { meets, daysUsing, hasInvalidDate: false };
+};
+
 export const configure = (bot: Telegraf<CommunityContext>) => {
   bot.command('mycomm', userMiddleware, commands.communityAdmin);
   bot.command('mycomms', userMiddleware, commands.myComms);
   if (process.env.COMMUNITY_CREATION_ENABLED === 'true') {
+    // Parsing of this values only happens once, they are not reparsed every time an user wants to create a new community
+    const { invalidEnvVars, minOrders, minVolume, minDays, minReputation } =
+      getCommunityThresholds();
+
     bot.command('community', userMiddleware, async ctx => {
       const { user } = ctx;
-
-      const parseOptionalNumber = (
-        raw: string | undefined,
-      ): { value: number | null; isValid: boolean } => {
-        if (raw == null || raw.trim() === '')
-          return { value: null, isValid: true };
-        const n = Number(raw);
-        if (Number.isFinite(n) && n >= 0) return { value: n, isValid: true };
-        return { value: null, isValid: false };
-      };
-
-      const thresholdResults = {
-        COMMUNITY_CREATION_MIN_ORDERS: parseOptionalNumber(
-          process.env.COMMUNITY_CREATION_MIN_ORDERS,
-        ),
-        COMMUNITY_CREATION_MIN_VOLUME: parseOptionalNumber(
-          process.env.COMMUNITY_CREATION_MIN_VOLUME,
-        ),
-        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: parseOptionalNumber(
-          process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT,
-        ),
-        COMMUNITY_CREATION_MIN_REPUTATION: parseOptionalNumber(
-          process.env.COMMUNITY_CREATION_MIN_REPUTATION,
-        ),
-      };
-
-      const invalidEnvVars = Object.entries(thresholdResults)
-        .filter(([_, res]) => !res.isValid)
-        .map(([key]) => key);
 
       if (invalidEnvVars.length > 0) {
         logger.error(
@@ -54,28 +104,38 @@ export const configure = (bot: Telegraf<CommunityContext>) => {
         return ctx.reply(ctx.i18n.t('generic_error'));
       }
 
-      const {
-        COMMUNITY_CREATION_MIN_ORDERS: { value: minOrders },
-        COMMUNITY_CREATION_MIN_VOLUME: { value: minVolume },
-        COMMUNITY_CREATION_MIN_DAYS_USING_BOT: { value: minDays },
-        COMMUNITY_CREATION_MIN_REPUTATION: { value: minReputation },
-      } = thresholdResults;
+      const { meets, daysUsing, hasInvalidDate } =
+        meetsCommunityCreationRequirements(user, {
+          minOrders,
+          minVolume,
+          minDays,
+          minReputation,
+        });
 
-      const daysUsing = Math.floor(
-        (Date.now() - new Date(user.created_at).getTime()) / 86400000,
-      );
-
-      const meetsRequirements =
-        (minOrders === null || user.trades_completed >= minOrders) &&
-        (minVolume === null || user.volume_traded >= minVolume) &&
-        (minDays === null || daysUsing >= minDays) &&
-        (minReputation === null || user.total_rating >= minReputation);
-
-      if (!meetsRequirements) {
+      if (hasInvalidDate) {
         logger.error(
+          `User ${user.tg_id} has invalid created_at timestamp: ${user.created_at}`,
+        );
+        return ctx.reply(ctx.i18n.t('generic_error'));
+      }
+
+      if (!meets) {
+        logger.warning(
           `User ${user.tg_id} tried to create a community but does not meet the requirements - orders: ${user.trades_completed}, volume: ${user.volume_traded}, days: ${daysUsing}, reputation: ${user.total_rating}`,
         );
-        return ctx.reply(ctx.i18n.t('community_creation_requirements_not_met'));
+
+        return ctx.reply(
+          ctx.i18n.t('community_creation_requirements_not_met', {
+            userOrders: user.trades_completed,
+            requiredOrders: minOrders ?? '-',
+            userVolume: user.volume_traded,
+            requiredVolume: minVolume ?? '-',
+            userDays: daysUsing,
+            requiredDays: minDays ?? '-',
+            userRep: user.total_rating,
+            requiredRep: minReputation ?? '-',
+          }),
+        );
       }
 
       await ctx.scene.enter('COMMUNITY_WIZARD_SCENE_ID', {

--- a/bot/modules/community/requirements.ts
+++ b/bot/modules/community/requirements.ts
@@ -1,0 +1,82 @@
+import { logger } from '../../../logger';
+
+export interface ParsedThresholds {
+  minOrders: number | null;
+  minVolume: number | null;
+  minDays: number | null;
+  minReputation: number | null;
+  invalidEnvVars: string[];
+}
+
+export interface UserMetrics {
+  tg_id: string;
+  trades_completed: number;
+  volume_traded: number;
+  total_rating: number;
+  created_at: Date | string;
+}
+
+export const parseOptionalNumber = (
+  raw: string | undefined,
+): { value: number | null; isValid: boolean } => {
+  if (raw == null || raw.trim() === '') return { value: null, isValid: true };
+  const n = Number(raw);
+  if (Number.isFinite(n) && n >= 0) return { value: n, isValid: true };
+  return { value: null, isValid: false };
+};
+
+export const getCommunityThresholds = (): ParsedThresholds => {
+  const thresholdResults = {
+    COMMUNITY_CREATION_MIN_ORDERS: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_ORDERS,
+    ),
+    COMMUNITY_CREATION_MIN_VOLUME_SATS: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_VOLUME_SATS,
+    ),
+    COMMUNITY_CREATION_MIN_DAYS_USING_BOT: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_DAYS_USING_BOT,
+    ),
+    COMMUNITY_CREATION_MIN_REPUTATION: parseOptionalNumber(
+      process.env.COMMUNITY_CREATION_MIN_REPUTATION,
+    ),
+  };
+
+  const invalidEnvVars = Object.entries(thresholdResults)
+    .filter(([_, res]) => !res.isValid)
+    .map(([key]) => key);
+
+  if (invalidEnvVars.length > 0) {
+    logger.error(
+      `Invalid COMMUNITY_CREATION_* threshold configuration: ${invalidEnvVars.join(', ')}`,
+    );
+  }
+
+  return {
+    minOrders: thresholdResults.COMMUNITY_CREATION_MIN_ORDERS.value,
+    minVolume: thresholdResults.COMMUNITY_CREATION_MIN_VOLUME_SATS.value,
+    minDays: thresholdResults.COMMUNITY_CREATION_MIN_DAYS_USING_BOT.value,
+    minReputation: thresholdResults.COMMUNITY_CREATION_MIN_REPUTATION.value,
+    invalidEnvVars,
+  };
+};
+
+export const meetsCommunityCreationRequirements = (
+  user: UserMetrics,
+  thresholds: Omit<ParsedThresholds, 'invalidEnvVars'>,
+): { meets: boolean; daysUsing: number | null; hasInvalidDate: boolean } => {
+  const createdAtTime = new Date(user.created_at).getTime();
+  if (!Number.isFinite(createdAtTime)) {
+    return { meets: false, daysUsing: null, hasInvalidDate: true };
+  }
+
+  const daysUsing = Math.floor((Date.now() - createdAtTime) / 86400000);
+  const { minOrders, minVolume, minDays, minReputation } = thresholds;
+
+  const meets =
+    (minOrders === null || user.trades_completed >= minOrders) &&
+    (minVolume === null || user.volume_traded >= minVolume) &&
+    (minDays === null || daysUsing >= minDays) &&
+    (minReputation === null || user.total_rating >= minReputation);
+
+  return { meets, daysUsing, hasInvalidDate: false };
+};

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -722,12 +722,11 @@ payment_methods_reset: "Zahlungsmethoden entfernt. Benutzer können jetzt belieb
 payment_methods_wizard_commands: "/reset — alle Zahlungsmethoden entfernen und Standardverhalten wiederherstellen\n/exit — ohne Speichern beenden"
 community_disabled_by_admin: Ein Administrator hat deine Community ${communityName} deaktiviert
 community_enabled_by_admin: Ein Administrator hat deine Community ${communityName} wieder aktiviert
-community_creation_requirements_not_met: |
-  Du erfüllst nicht die Anforderungen zur Erstellung einer Community:
-  * Bestellungen: ${userOrders} / ${requiredOrders}
-  * Volumen: ${userVolume} / ${requiredVolume}
-  * Tage der Nutzung des Bots: ${userDays} / ${requiredDays}
-  * Reputation: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "Du erfüllst nicht die Anforderungen zur Erstellung einer Community:"
+community_creation_requirements_not_met_orders: "* Bestellungen: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Volumen: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Tage der Nutzung des Bots: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Reputation: ${userRep} / ${requiredRep}"
 community_already_disabled: Diese Community ist bereits deaktiviert
 community_already_enabled: Diese Community ist bereits aktiviert
 ambiguous_community_input: Mehrere Communities stimmen mit diesem Benutzernamen überein, bitte verwende stattdessen die Community-ID

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -722,6 +722,7 @@ payment_methods_reset: "Zahlungsmethoden entfernt. Benutzer können jetzt belieb
 payment_methods_wizard_commands: "/reset — alle Zahlungsmethoden entfernen und Standardverhalten wiederherstellen\n/exit — ohne Speichern beenden"
 community_disabled_by_admin: Ein Administrator hat deine Community ${communityName} deaktiviert
 community_enabled_by_admin: Ein Administrator hat deine Community ${communityName} wieder aktiviert
+community_creation_requirements_not_met: "Du erfüllst nicht die Anforderungen zur Erstellung einer Community"
 community_already_disabled: Diese Community ist bereits deaktiviert
 community_already_enabled: Diese Community ist bereits aktiviert
 ambiguous_community_input: Mehrere Communities stimmen mit diesem Benutzernamen überein, bitte verwende stattdessen die Community-ID

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -722,7 +722,12 @@ payment_methods_reset: "Zahlungsmethoden entfernt. Benutzer können jetzt belieb
 payment_methods_wizard_commands: "/reset — alle Zahlungsmethoden entfernen und Standardverhalten wiederherstellen\n/exit — ohne Speichern beenden"
 community_disabled_by_admin: Ein Administrator hat deine Community ${communityName} deaktiviert
 community_enabled_by_admin: Ein Administrator hat deine Community ${communityName} wieder aktiviert
-community_creation_requirements_not_met: "Du erfüllst nicht die Anforderungen zur Erstellung einer Community"
+community_creation_requirements_not_met: |
+  Du erfüllst nicht die Anforderungen zur Erstellung einer Community:
+  * Bestellungen: ${userOrders} / ${requiredOrders}
+  * Volumen: ${userVolume} / ${requiredVolume}
+  * Tage der Nutzung des Bots: ${userDays} / ${requiredDays}
+  * Reputation: ${userRep} / ${requiredRep}
 community_already_disabled: Diese Community ist bereits deaktiviert
 community_already_enabled: Diese Community ist bereits aktiviert
 ambiguous_community_input: Mehrere Communities stimmen mit diesem Benutzernamen überein, bitte verwende stattdessen die Community-ID

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -728,7 +728,12 @@ payment_methods_reset: "Payment methods removed. Users can now enter any payment
 payment_methods_wizard_commands: "/reset — remove all payment methods and restore default behavior\n/exit — exit without saving"
 community_disabled_by_admin: An administrator has disabled your community ${communityName}
 community_enabled_by_admin: An administrator has re-enabled your community ${communityName}
-community_creation_requirements_not_met: "You don't meet the requirements to create a community"
+community_creation_requirements_not_met: |
+  You do not meet the requirements to create a community:
+  * Orders: ${userOrders} / ${requiredOrders}
+  * Volume: ${userVolume} / ${requiredVolume}
+  * Days using the bot: ${userDays} / ${requiredDays}
+  * Reputation: ${userRep} / ${requiredRep}
 community_already_disabled: This community is already disabled
 community_already_enabled: This community is already enabled
 ambiguous_community_input: Multiple communities match that username, please use the community ID instead

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -728,12 +728,11 @@ payment_methods_reset: "Payment methods removed. Users can now enter any payment
 payment_methods_wizard_commands: "/reset — remove all payment methods and restore default behavior\n/exit — exit without saving"
 community_disabled_by_admin: An administrator has disabled your community ${communityName}
 community_enabled_by_admin: An administrator has re-enabled your community ${communityName}
-community_creation_requirements_not_met: |
-  You do not meet the requirements to create a community:
-  * Orders: ${userOrders} / ${requiredOrders}
-  * Volume: ${userVolume} / ${requiredVolume}
-  * Days using the bot: ${userDays} / ${requiredDays}
-  * Reputation: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "You do not meet the requirements to create a community:"
+community_creation_requirements_not_met_orders: "* Orders: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Volume: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Days using the bot: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Reputation: ${userRep} / ${requiredRep}"
 community_already_disabled: This community is already disabled
 community_already_enabled: This community is already enabled
 ambiguous_community_input: Multiple communities match that username, please use the community ID instead

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -728,6 +728,7 @@ payment_methods_reset: "Payment methods removed. Users can now enter any payment
 payment_methods_wizard_commands: "/reset — remove all payment methods and restore default behavior\n/exit — exit without saving"
 community_disabled_by_admin: An administrator has disabled your community ${communityName}
 community_enabled_by_admin: An administrator has re-enabled your community ${communityName}
+community_creation_requirements_not_met: "You don't meet the requirements to create a community"
 community_already_disabled: This community is already disabled
 community_already_enabled: This community is already enabled
 ambiguous_community_input: Multiple communities match that username, please use the community ID instead

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -725,12 +725,11 @@ payment_methods_reset: "Métodos de pago eliminados. Los usuarios ahora pueden i
 payment_methods_wizard_commands: "/reset — eliminar todos los métodos de pago y restaurar el comportamiento predeterminado\n/exit — salir sin guardar"
 community_disabled_by_admin: Un administrador ha deshabilitado tu comunidad ${communityName}
 community_enabled_by_admin: Un administrador ha reactivado tu comunidad ${communityName}
-community_creation_requirements_not_met: |
-  No cumples con los requisitos para crear una comunidad:
-  * Órdenes: ${userOrders} / ${requiredOrders}
-  * Volumen: ${userVolume} / ${requiredVolume}
-  * Días usando el bot: ${userDays} / ${requiredDays}
-  * Reputación: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "No cumples con los requisitos para crear una comunidad:"
+community_creation_requirements_not_met_orders: "* Órdenes: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Volumen: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Días usando el bot: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Reputación: ${userRep} / ${requiredRep}"
 community_already_disabled: Esta comunidad ya está deshabilitada
 community_already_enabled: Esta comunidad ya está habilitada
 ambiguous_community_input: Varias comunidades coinciden con ese nombre de usuario, por favor usa el ID de la comunidad

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -725,7 +725,12 @@ payment_methods_reset: "Métodos de pago eliminados. Los usuarios ahora pueden i
 payment_methods_wizard_commands: "/reset — eliminar todos los métodos de pago y restaurar el comportamiento predeterminado\n/exit — salir sin guardar"
 community_disabled_by_admin: Un administrador ha deshabilitado tu comunidad ${communityName}
 community_enabled_by_admin: Un administrador ha reactivado tu comunidad ${communityName}
-community_creation_requirements_not_met: "No cumples con los requisitos para crear una comunidad"
+community_creation_requirements_not_met: |
+  No cumples con los requisitos para crear una comunidad:
+  * Órdenes: ${userOrders} / ${requiredOrders}
+  * Volumen: ${userVolume} / ${requiredVolume}
+  * Días usando el bot: ${userDays} / ${requiredDays}
+  * Reputación: ${userRep} / ${requiredRep}
 community_already_disabled: Esta comunidad ya está deshabilitada
 community_already_enabled: Esta comunidad ya está habilitada
 ambiguous_community_input: Varias comunidades coinciden con ese nombre de usuario, por favor usa el ID de la comunidad

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -725,6 +725,7 @@ payment_methods_reset: "Métodos de pago eliminados. Los usuarios ahora pueden i
 payment_methods_wizard_commands: "/reset — eliminar todos los métodos de pago y restaurar el comportamiento predeterminado\n/exit — salir sin guardar"
 community_disabled_by_admin: Un administrador ha deshabilitado tu comunidad ${communityName}
 community_enabled_by_admin: Un administrador ha reactivado tu comunidad ${communityName}
+community_creation_requirements_not_met: "No cumples con los requisitos para crear una comunidad"
 community_already_disabled: Esta comunidad ya está deshabilitada
 community_already_enabled: Esta comunidad ya está habilitada
 ambiguous_community_input: Varias comunidades coinciden con ese nombre de usuario, por favor usa el ID de la comunidad

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -821,12 +821,11 @@ payment_methods_reset: "روش‌های پرداخت حذف شدند. کاربر
 payment_methods_wizard_commands: "/reset — حذف همه روش‌های پرداخت و بازگرداندن رفتار پیش‌فرض\n/exit — خروج بدون ذخیره"
 community_disabled_by_admin: یک مدیر جامعه ${communityName} شما را غیرفعال کرد
 community_enabled_by_admin: یک مدیر جامعه ${communityName} شما را دوباره فعال کرد
-community_creation_requirements_not_met: |
-  شما شرایط لازم برای ایجاد جامعه را ندارید:
-  * سفارش‌ها: ${userOrders} / ${requiredOrders}
-  * حجم: ${userVolume} / ${requiredVolume}
-  * روزهای استفاده از ربات: ${userDays} / ${requiredDays}
-  * اعتبار: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "شما شرایط لازم برای ایجاد جامعه را ندارید:"
+community_creation_requirements_not_met_orders: "* سفارش‌ها: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* حجم: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* روزهای استفاده از ربات: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* اعتبار: ${userRep} / ${requiredRep}"
 community_already_disabled: این جامعه از قبل غیرفعال است
 community_already_enabled: این جامعه از قبل فعال است
 ambiguous_community_input: چندین جامعه با این نام کاربری مطابقت دارند، لطفاً از شناسه جامعه استفاده کنید

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -821,7 +821,12 @@ payment_methods_reset: "روش‌های پرداخت حذف شدند. کاربر
 payment_methods_wizard_commands: "/reset — حذف همه روش‌های پرداخت و بازگرداندن رفتار پیش‌فرض\n/exit — خروج بدون ذخیره"
 community_disabled_by_admin: یک مدیر جامعه ${communityName} شما را غیرفعال کرد
 community_enabled_by_admin: یک مدیر جامعه ${communityName} شما را دوباره فعال کرد
-community_creation_requirements_not_met: "شما شرایط لازم برای ایجاد جامعه را ندارید"
+community_creation_requirements_not_met: |
+  شما شرایط لازم برای ایجاد جامعه را ندارید:
+  * سفارش‌ها: ${userOrders} / ${requiredOrders}
+  * حجم: ${userVolume} / ${requiredVolume}
+  * روزهای استفاده از ربات: ${userDays} / ${requiredDays}
+  * اعتبار: ${userRep} / ${requiredRep}
 community_already_disabled: این جامعه از قبل غیرفعال است
 community_already_enabled: این جامعه از قبل فعال است
 ambiguous_community_input: چندین جامعه با این نام کاربری مطابقت دارند، لطفاً از شناسه جامعه استفاده کنید

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -821,6 +821,7 @@ payment_methods_reset: "روش‌های پرداخت حذف شدند. کاربر
 payment_methods_wizard_commands: "/reset — حذف همه روش‌های پرداخت و بازگرداندن رفتار پیش‌فرض\n/exit — خروج بدون ذخیره"
 community_disabled_by_admin: یک مدیر جامعه ${communityName} شما را غیرفعال کرد
 community_enabled_by_admin: یک مدیر جامعه ${communityName} شما را دوباره فعال کرد
+community_creation_requirements_not_met: "شما شرایط لازم برای ایجاد جامعه را ندارید"
 community_already_disabled: این جامعه از قبل غیرفعال است
 community_already_enabled: این جامعه از قبل فعال است
 ambiguous_community_input: چندین جامعه با این نام کاربری مطابقت دارند، لطفاً از شناسه جامعه استفاده کنید

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -721,7 +721,12 @@ payment_methods_reset: "Méthodes de paiement supprimées. Les utilisateurs peuv
 payment_methods_wizard_commands: "/reset — supprimer toutes les méthodes de paiement et restaurer le comportement par défaut\n/exit — quitter sans enregistrer"
 community_disabled_by_admin: Un administrateur a désactivé votre communauté ${communityName}
 community_enabled_by_admin: Un administrateur a réactivé votre communauté ${communityName}
-community_creation_requirements_not_met: "Vous ne remplissez pas les conditions pour créer une communauté"
+community_creation_requirements_not_met: |
+  Vous ne remplissez pas les conditions pour créer une communauté :
+  * Commandes : ${userOrders} / ${requiredOrders}
+  * Volume : ${userVolume} / ${requiredVolume}
+  * Jours d'utilisation du bot : ${userDays} / ${requiredDays}
+  * Réputation : ${userRep} / ${requiredRep}
 community_already_disabled: Cette communauté est déjà désactivée
 community_already_enabled: Cette communauté est déjà activée
 ambiguous_community_input: Plusieurs communautés correspondent à ce nom d'utilisateur, veuillez utiliser l'ID de la communauté à la place

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -721,6 +721,7 @@ payment_methods_reset: "Méthodes de paiement supprimées. Les utilisateurs peuv
 payment_methods_wizard_commands: "/reset — supprimer toutes les méthodes de paiement et restaurer le comportement par défaut\n/exit — quitter sans enregistrer"
 community_disabled_by_admin: Un administrateur a désactivé votre communauté ${communityName}
 community_enabled_by_admin: Un administrateur a réactivé votre communauté ${communityName}
+community_creation_requirements_not_met: "Vous ne remplissez pas les conditions pour créer une communauté"
 community_already_disabled: Cette communauté est déjà désactivée
 community_already_enabled: Cette communauté est déjà activée
 ambiguous_community_input: Plusieurs communautés correspondent à ce nom d'utilisateur, veuillez utiliser l'ID de la communauté à la place

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -721,12 +721,11 @@ payment_methods_reset: "Méthodes de paiement supprimées. Les utilisateurs peuv
 payment_methods_wizard_commands: "/reset — supprimer toutes les méthodes de paiement et restaurer le comportement par défaut\n/exit — quitter sans enregistrer"
 community_disabled_by_admin: Un administrateur a désactivé votre communauté ${communityName}
 community_enabled_by_admin: Un administrateur a réactivé votre communauté ${communityName}
-community_creation_requirements_not_met: |
-  Vous ne remplissez pas les conditions pour créer une communauté :
-  * Commandes : ${userOrders} / ${requiredOrders}
-  * Volume : ${userVolume} / ${requiredVolume}
-  * Jours d'utilisation du bot : ${userDays} / ${requiredDays}
-  * Réputation : ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "Vous ne remplissez pas les conditions pour créer une communauté :"
+community_creation_requirements_not_met_orders: "* Commandes : ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Volume : ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Jours d'utilisation du bot : ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Réputation : ${userRep} / ${requiredRep}"
 community_already_disabled: Cette communauté est déjà désactivée
 community_already_enabled: Cette communauté est déjà activée
 ambiguous_community_input: Plusieurs communautés correspondent à ce nom d'utilisateur, veuillez utiliser l'ID de la communauté à la place

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -719,7 +719,12 @@ payment_methods_reset: "Metodi di pagamento rimossi. Gli utenti possono ora inse
 payment_methods_wizard_commands: "/reset — rimuovere tutti i metodi di pagamento e ripristinare il comportamento predefinito\n/exit — uscire senza salvare"
 community_disabled_by_admin: Un amministratore ha disabilitato la tua comunità ${communityName}
 community_enabled_by_admin: Un amministratore ha riabilitato la tua comunità ${communityName}
-community_creation_requirements_not_met: "Non soddisfi i requisiti per creare una comunità"
+community_creation_requirements_not_met: |
+  Non soddisfi i requisiti per creare una comunità:
+  * Ordini: ${userOrders} / ${requiredOrders}
+  * Volume: ${userVolume} / ${requiredVolume}
+  * Giorni di utilizzo del bot: ${userDays} / ${requiredDays}
+  * Reputazione: ${userRep} / ${requiredRep}
 community_already_disabled: Questa comunità è già disabilitata
 community_already_enabled: Questa comunità è già abilitata
 ambiguous_community_input: Più comunità corrispondono a quel nome utente, usa invece l'ID della comunità

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -719,12 +719,11 @@ payment_methods_reset: "Metodi di pagamento rimossi. Gli utenti possono ora inse
 payment_methods_wizard_commands: "/reset — rimuovere tutti i metodi di pagamento e ripristinare il comportamento predefinito\n/exit — uscire senza salvare"
 community_disabled_by_admin: Un amministratore ha disabilitato la tua comunità ${communityName}
 community_enabled_by_admin: Un amministratore ha riabilitato la tua comunità ${communityName}
-community_creation_requirements_not_met: |
-  Non soddisfi i requisiti per creare una comunità:
-  * Ordini: ${userOrders} / ${requiredOrders}
-  * Volume: ${userVolume} / ${requiredVolume}
-  * Giorni di utilizzo del bot: ${userDays} / ${requiredDays}
-  * Reputazione: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "Non soddisfi i requisiti per creare una comunità:"
+community_creation_requirements_not_met_orders: "* Ordini: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Volume: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Giorni di utilizzo del bot: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Reputazione: ${userRep} / ${requiredRep}"
 community_already_disabled: Questa comunità è già disabilitata
 community_already_enabled: Questa comunità è già abilitata
 ambiguous_community_input: Più comunità corrispondono a quel nome utente, usa invece l'ID della comunità

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -719,6 +719,7 @@ payment_methods_reset: "Metodi di pagamento rimossi. Gli utenti possono ora inse
 payment_methods_wizard_commands: "/reset — rimuovere tutti i metodi di pagamento e ripristinare il comportamento predefinito\n/exit — uscire senza salvare"
 community_disabled_by_admin: Un amministratore ha disabilitato la tua comunità ${communityName}
 community_enabled_by_admin: Un amministratore ha riabilitato la tua comunità ${communityName}
+community_creation_requirements_not_met: "Non soddisfi i requisiti per creare una comunità"
 community_already_disabled: Questa comunità è già disabilitata
 community_already_enabled: Questa comunità è già abilitata
 ambiguous_community_input: Più comunità corrispondono a quel nome utente, usa invece l'ID della comunità

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -719,6 +719,7 @@ payment_methods_reset: "결제 방법이 삭제되었습니다. 이제 사용자
 payment_methods_wizard_commands: "/reset — 모든 결제 방법을 삭제하고 기본 동작을 복원합니다\n/exit — 저장하지 않고 종료"
 community_disabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 비활성화했습니다
 community_enabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 다시 활성화했습니다
+community_creation_requirements_not_met: "커뮤니티를 생성하기 위한 요건을 충족하지 못했습니다"
 community_already_disabled: 이 커뮤니티는 이미 비활성화되어 있습니다
 community_already_enabled: 이 커뮤니티는 이미 활성화되어 있습니다
 ambiguous_community_input: 해당 사용자 이름과 일치하는 커뮤니티가 여러 개 있습니다. 커뮤니티 ID를 사용해 주세요

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -719,7 +719,12 @@ payment_methods_reset: "결제 방법이 삭제되었습니다. 이제 사용자
 payment_methods_wizard_commands: "/reset — 모든 결제 방법을 삭제하고 기본 동작을 복원합니다\n/exit — 저장하지 않고 종료"
 community_disabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 비활성화했습니다
 community_enabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 다시 활성화했습니다
-community_creation_requirements_not_met: "커뮤니티를 생성하기 위한 요건을 충족하지 못했습니다"
+community_creation_requirements_not_met: |
+  커뮤니티를 생성하기 위한 요건을 충족하지 못했습니다:
+  * 주문: ${userOrders} / ${requiredOrders}
+  * 거래량: ${userVolume} / ${requiredVolume}
+  * 봇 사용 일수: ${userDays} / ${requiredDays}
+  * 평판: ${userRep} / ${requiredRep}
 community_already_disabled: 이 커뮤니티는 이미 비활성화되어 있습니다
 community_already_enabled: 이 커뮤니티는 이미 활성화되어 있습니다
 ambiguous_community_input: 해당 사용자 이름과 일치하는 커뮤니티가 여러 개 있습니다. 커뮤니티 ID를 사용해 주세요

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -719,12 +719,11 @@ payment_methods_reset: "결제 방법이 삭제되었습니다. 이제 사용자
 payment_methods_wizard_commands: "/reset — 모든 결제 방법을 삭제하고 기본 동작을 복원합니다\n/exit — 저장하지 않고 종료"
 community_disabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 비활성화했습니다
 community_enabled_by_admin: 관리자가 커뮤니티 ${communityName}을(를) 다시 활성화했습니다
-community_creation_requirements_not_met: |
-  커뮤니티를 생성하기 위한 요건을 충족하지 못했습니다:
-  * 주문: ${userOrders} / ${requiredOrders}
-  * 거래량: ${userVolume} / ${requiredVolume}
-  * 봇 사용 일수: ${userDays} / ${requiredDays}
-  * 평판: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "커뮤니티를 생성하기 위한 요건을 충족하지 못했습니다:"
+community_creation_requirements_not_met_orders: "* 주문: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* 거래량: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* 봇 사용 일수: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* 평판: ${userRep} / ${requiredRep}"
 community_already_disabled: 이 커뮤니티는 이미 비활성화되어 있습니다
 community_already_enabled: 이 커뮤니티는 이미 활성화되어 있습니다
 ambiguous_community_input: 해당 사용자 이름과 일치하는 커뮤니티가 여러 개 있습니다. 커뮤니티 ID를 사용해 주세요

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -721,12 +721,11 @@ payment_methods_reset: "Métodos de pagamento removidos. Os usuários agora pode
 payment_methods_wizard_commands: "/reset — remover todos os métodos de pagamento e restaurar o comportamento padrão\n/exit — sair sem salvar"
 community_disabled_by_admin: Um administrador desativou sua comunidade ${communityName}
 community_enabled_by_admin: Um administrador reativou sua comunidade ${communityName}
-community_creation_requirements_not_met: |
-  Você não atende aos requisitos para criar uma comunidade:
-  * Pedidos: ${userOrders} / ${requiredOrders}
-  * Volume: ${userVolume} / ${requiredVolume}
-  * Dias usando o bot: ${userDays} / ${requiredDays}
-  * Reputação: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "Você não atende aos requisitos para criar uma comunidade:"
+community_creation_requirements_not_met_orders: "* Pedidos: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Volume: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Dias usando o bot: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Reputação: ${userRep} / ${requiredRep}"
 community_already_disabled: Esta comunidade já está desativada
 community_already_enabled: Esta comunidade já está ativada
 ambiguous_community_input: Várias comunidades correspondem a esse nome de usuário, por favor use o ID da comunidade

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -721,6 +721,7 @@ payment_methods_reset: "Métodos de pagamento removidos. Os usuários agora pode
 payment_methods_wizard_commands: "/reset — remover todos os métodos de pagamento e restaurar o comportamento padrão\n/exit — sair sem salvar"
 community_disabled_by_admin: Um administrador desativou sua comunidade ${communityName}
 community_enabled_by_admin: Um administrador reativou sua comunidade ${communityName}
+community_creation_requirements_not_met: "Você não atende aos requisitos para criar uma comunidade"
 community_already_disabled: Esta comunidade já está desativada
 community_already_enabled: Esta comunidade já está ativada
 ambiguous_community_input: Várias comunidades correspondem a esse nome de usuário, por favor use o ID da comunidade

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -721,7 +721,12 @@ payment_methods_reset: "Métodos de pagamento removidos. Os usuários agora pode
 payment_methods_wizard_commands: "/reset — remover todos os métodos de pagamento e restaurar o comportamento padrão\n/exit — sair sem salvar"
 community_disabled_by_admin: Um administrador desativou sua comunidade ${communityName}
 community_enabled_by_admin: Um administrador reativou sua comunidade ${communityName}
-community_creation_requirements_not_met: "Você não atende aos requisitos para criar uma comunidade"
+community_creation_requirements_not_met: |
+  Você não atende aos requisitos para criar uma comunidade:
+  * Pedidos: ${userOrders} / ${requiredOrders}
+  * Volume: ${userVolume} / ${requiredVolume}
+  * Dias usando o bot: ${userDays} / ${requiredDays}
+  * Reputação: ${userRep} / ${requiredRep}
 community_already_disabled: Esta comunidade já está desativada
 community_already_enabled: Esta comunidade já está ativada
 ambiguous_community_input: Várias comunidades correspondem a esse nome de usuário, por favor use o ID da comunidade

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -722,12 +722,11 @@ payment_methods_reset: "Способы оплаты удалены. Пользо
 payment_methods_wizard_commands: "/reset — удалить все способы оплаты и восстановить поведение по умолчанию\n/exit — выйти без сохранения"
 community_disabled_by_admin: Администратор отключил ваше сообщество ${communityName}
 community_enabled_by_admin: Администратор повторно включил ваше сообщество ${communityName}
-community_creation_requirements_not_met: |
-  Вы не соответствуете требованиям для создания сообщества:
-  * Заказы: ${userOrders} / ${requiredOrders}
-  * Объем: ${userVolume} / ${requiredVolume}
-  * Дней использования бота: ${userDays} / ${requiredDays}
-  * Репутация: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "Вы не соответствуете требованиям для создания сообщества:"
+community_creation_requirements_not_met_orders: "* Заказы: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Объем: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Дней использования бота: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Репутация: ${userRep} / ${requiredRep}"
 community_already_disabled: Это сообщество уже отключено
 community_already_enabled: Это сообщество уже включено
 ambiguous_community_input: Несколько сообществ соответствуют этому имени пользователя, пожалуйста, используйте ID сообщества

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -722,7 +722,12 @@ payment_methods_reset: "Способы оплаты удалены. Пользо
 payment_methods_wizard_commands: "/reset — удалить все способы оплаты и восстановить поведение по умолчанию\n/exit — выйти без сохранения"
 community_disabled_by_admin: Администратор отключил ваше сообщество ${communityName}
 community_enabled_by_admin: Администратор повторно включил ваше сообщество ${communityName}
-community_creation_requirements_not_met: "Вы не соответствуете требованиям для создания сообщества"
+community_creation_requirements_not_met: |
+  Вы не соответствуете требованиям для создания сообщества:
+  * Заказы: ${userOrders} / ${requiredOrders}
+  * Объем: ${userVolume} / ${requiredVolume}
+  * Дней использования бота: ${userDays} / ${requiredDays}
+  * Репутация: ${userRep} / ${requiredRep}
 community_already_disabled: Это сообщество уже отключено
 community_already_enabled: Это сообщество уже включено
 ambiguous_community_input: Несколько сообществ соответствуют этому имени пользователя, пожалуйста, используйте ID сообщества

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -722,6 +722,7 @@ payment_methods_reset: "Способы оплаты удалены. Пользо
 payment_methods_wizard_commands: "/reset — удалить все способы оплаты и восстановить поведение по умолчанию\n/exit — выйти без сохранения"
 community_disabled_by_admin: Администратор отключил ваше сообщество ${communityName}
 community_enabled_by_admin: Администратор повторно включил ваше сообщество ${communityName}
+community_creation_requirements_not_met: "Вы не соответствуете требованиям для создания сообщества"
 community_already_disabled: Это сообщество уже отключено
 community_already_enabled: Это сообщество уже включено
 ambiguous_community_input: Несколько сообществ соответствуют этому имени пользователя, пожалуйста, используйте ID сообщества

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -718,7 +718,12 @@ payment_methods_reset: "Способи оплати видалено. Корис
 payment_methods_wizard_commands: "/reset — видалити всі способи оплати та відновити поведінку за замовчуванням\n/exit — вийти без збереження"
 community_disabled_by_admin: Адміністратор вимкнув вашу спільноту ${communityName}
 community_enabled_by_admin: Адміністратор повторно увімкнув вашу спільноту ${communityName}
-community_creation_requirements_not_met: "Ви не відповідаєте вимогам для створення спільноти"
+community_creation_requirements_not_met: |
+  Ви не відповідаєте вимогам для створення спільноти:
+  * Замовлення: ${userOrders} / ${requiredOrders}
+  * Обсяг: ${userVolume} / ${requiredVolume}
+  * Днів використання бота: ${userDays} / ${requiredDays}
+  * Репутація: ${userRep} / ${requiredRep}
 community_already_disabled: Ця спільнота вже вимкнена
 community_already_enabled: Ця спільнота вже увімкнена
 ambiguous_community_input: Кілька спільнот відповідають цьому імені користувача, будь ласка, використовуйте ID спільноти

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -718,6 +718,7 @@ payment_methods_reset: "Способи оплати видалено. Корис
 payment_methods_wizard_commands: "/reset — видалити всі способи оплати та відновити поведінку за замовчуванням\n/exit — вийти без збереження"
 community_disabled_by_admin: Адміністратор вимкнув вашу спільноту ${communityName}
 community_enabled_by_admin: Адміністратор повторно увімкнув вашу спільноту ${communityName}
+community_creation_requirements_not_met: "Ви не відповідаєте вимогам для створення спільноти"
 community_already_disabled: Ця спільнота вже вимкнена
 community_already_enabled: Ця спільнота вже увімкнена
 ambiguous_community_input: Кілька спільнот відповідають цьому імені користувача, будь ласка, використовуйте ID спільноти

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -718,12 +718,11 @@ payment_methods_reset: "Способи оплати видалено. Корис
 payment_methods_wizard_commands: "/reset — видалити всі способи оплати та відновити поведінку за замовчуванням\n/exit — вийти без збереження"
 community_disabled_by_admin: Адміністратор вимкнув вашу спільноту ${communityName}
 community_enabled_by_admin: Адміністратор повторно увімкнув вашу спільноту ${communityName}
-community_creation_requirements_not_met: |
-  Ви не відповідаєте вимогам для створення спільноти:
-  * Замовлення: ${userOrders} / ${requiredOrders}
-  * Обсяг: ${userVolume} / ${requiredVolume}
-  * Днів використання бота: ${userDays} / ${requiredDays}
-  * Репутація: ${userRep} / ${requiredRep}
+community_creation_requirements_not_met_header: "Ви не відповідаєте вимогам для створення спільноти:"
+community_creation_requirements_not_met_orders: "* Замовлення: ${userOrders} / ${requiredOrders}"
+community_creation_requirements_not_met_volume: "* Обсяг: ${userVolume} / ${requiredVolume}"
+community_creation_requirements_not_met_days: "* Днів використання бота: ${userDays} / ${requiredDays}"
+community_creation_requirements_not_met_rep: "* Репутація: ${userRep} / ${requiredRep}"
 community_already_disabled: Ця спільнота вже вимкнена
 community_already_enabled: Ця спільнота вже увімкнена
 ambiguous_community_input: Кілька спільнот відповідають цьому імені користувача, будь ласка, використовуйте ID спільноти

--- a/tests/bot/modules/community/requirements.spec.ts
+++ b/tests/bot/modules/community/requirements.spec.ts
@@ -1,0 +1,116 @@
+import {
+  parseOptionalNumber,
+  meetsCommunityCreationRequirements,
+  getCommunityThresholds,
+} from '../../../../bot/modules/community/requirements';
+const { expect } = require('chai');
+
+describe('Community Requirements', () => {
+  describe('parseOptionalNumber', () => {
+    it('should return { value: null, isValid: true } for undefined', () => {
+      const res = parseOptionalNumber(undefined);
+      expect(res).to.deep.equal({ value: null, isValid: true });
+    });
+    it('should return { value: null, isValid: true } for empty string', () => {
+      const res = parseOptionalNumber('  ');
+      expect(res).to.deep.equal({ value: null, isValid: true });
+    });
+    it('should return valid number for valid string', () => {
+      const res = parseOptionalNumber('100');
+      expect(res).to.deep.equal({ value: 100, isValid: true });
+    });
+    it('should return invalid for negative number', () => {
+      const res = parseOptionalNumber('-5');
+      expect(res).to.deep.equal({ value: null, isValid: false });
+    });
+    it('should return invalid for non-numeric string', () => {
+      const res = parseOptionalNumber('abc');
+      expect(res).to.deep.equal({ value: null, isValid: false });
+    });
+  });
+
+  describe('getCommunityThresholds', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should parse valid thresholds correctly', () => {
+      process.env.COMMUNITY_CREATION_MIN_ORDERS = '10';
+      process.env.COMMUNITY_CREATION_MIN_VOLUME_SATS = '1000';
+      const result = getCommunityThresholds();
+      expect(result.minOrders).to.equal(10);
+      expect(result.minVolume).to.equal(1000);
+      expect(result.invalidEnvVars).to.have.lengthOf(0);
+    });
+
+    it('should return invalidEnvVars for invalid thresholds', () => {
+      process.env.COMMUNITY_CREATION_MIN_ORDERS = 'invalid';
+      const result = getCommunityThresholds();
+      expect(result.invalidEnvVars).to.contain('COMMUNITY_CREATION_MIN_ORDERS');
+    });
+  });
+
+  describe('meetsCommunityCreationRequirements', () => {
+    const user = {
+      tg_id: '1',
+      trades_completed: 10,
+      volume_traded: 1000,
+      total_rating: 4.5,
+      created_at: new Date(Date.now() - 100 * 86400000).toISOString(), // 100 days ago
+    };
+
+    it('should meet requirements when all thresholds are null', () => {
+      const thresholds = {
+        minOrders: null,
+        minVolume: null,
+        minDays: null,
+        minReputation: null,
+      };
+      const result = meetsCommunityCreationRequirements(user, thresholds);
+      expect(result.meets).to.equal(true);
+    });
+
+    it('should fail if orders threshold not met', () => {
+      const thresholds = {
+        minOrders: 20,
+        minVolume: null,
+        minDays: null,
+        minReputation: null,
+      };
+      const result = meetsCommunityCreationRequirements(user, thresholds);
+      expect(result.meets).to.equal(false);
+    });
+
+    it('should meet if all thresholds met', () => {
+      const thresholds = {
+        minOrders: 5,
+        minVolume: 500,
+        minDays: 50,
+        minReputation: 4,
+      };
+      const result = meetsCommunityCreationRequirements(user, thresholds);
+      expect(result.meets).to.equal(true);
+    });
+
+    it('should return hasInvalidDate true for invalid date', () => {
+      const invalidUser = { ...user, created_at: 'invalid-date' };
+      const thresholds = {
+        minOrders: null,
+        minVolume: null,
+        minDays: null,
+        minReputation: null,
+      };
+      const result = meetsCommunityCreationRequirements(
+        invalidUser,
+        thresholds,
+      );
+      expect(result.hasInvalidDate).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #838 
Continues #840 

Add environment-based minimum requirements to the /community command so only users who meet configurable thresholds can create a community
If any requirement is not met, the bot replies with a short error message and exits — no scene is entered
If an env var is not set, that restriction is simply not applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added community-creation eligibility checks (when enabled) using configurable minimum thresholds for open orders, trading volume, days using the bot, and reputation, with detailed “requirements not met” feedback.
* **Documentation**
  * Updated the configuration template (`.env-sample`) with optional community-creation minimum requirement settings (left unset to disable restrictions).
* **Localization**
  * Added new “requirements not met” message strings for English, German, Spanish, Persian, French, Italian, Korean, Portuguese, Russian, and Ukrainian.  
* **Tests**
  * Added unit tests for threshold parsing and eligibility evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->