### PR TITLE
Fix/cancelall pending only

### DIFF
--- a/bot/start.ts
+++ b/bot/start.ts
@@ -502,38 +502,17 @@ const initialize = (
   // pending orders are the ones that are not taken by another user
   bot.command('cancelall', userMiddleware, async (ctx: CommunityContext) => {
     try {
-      const pending_orders =
-        (await ordersActions.getOrders(ctx.user, 'PENDING')) || [];
-      const seller_orders =
-        (await ordersActions.getOrders(ctx.user, 'WAITING_BUYER_INVOICE')) ||
-        [];
-      const buyer_orders =
-        (await ordersActions.getOrders(ctx.user, 'WAITING_PAYMENT')) || [];
-
-      const orders = [...pending_orders, ...seller_orders, ...buyer_orders];
+      // /cancelall only cancels PENDING orders (published orders that nobody
+      // has taken yet). Orders already being taken (WAITING_PAYMENT /
+      // WAITING_BUYER_INVOICE) must be handled individually with /cancel or
+      // through a dispute, just like single /cancel rejects them.
+      const orders = (await ordersActions.getOrders(ctx.user, 'PENDING')) || [];
 
       if (orders.length === 0) {
         return await messages.notOrdersMessage(ctx);
       }
 
       for (const order of orders) {
-        // If a buyer is taking a sell offer and accidentally touch continue button we
-        // let the user to cancel
-        if (order.type === 'sell' && order.status === 'WAITING_BUYER_INVOICE') {
-          return await cancelAddInvoice(ctx, order);
-        }
-
-        // If a seller is taking a buy offer and accidentally touch continue button we
-        // let the user to cancel
-        if (order.type === 'buy' && order.status === 'WAITING_PAYMENT') {
-          return await cancelShowHoldInvoice(ctx, order);
-        }
-
-        // If a buyer wants cancel but the seller already pay the hold invoice
-        if (order.type === 'buy' && order.status === 'WAITING_BUYER_INVOICE') {
-          if (order.hash) await cancelHoldInvoice({ hash: order.hash });
-        }
-
         order.status = 'CANCELED';
         order.canceled_by = ctx.user.id;
         await order.save();

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -506,7 +506,12 @@ const initialize = (
       // has taken yet). Orders already being taken (WAITING_PAYMENT /
       // WAITING_BUYER_INVOICE) must be handled individually with /cancel or
       // through a dispute, just like single /cancel rejects them.
-      const orders = (await ordersActions.getOrders(ctx.user, 'PENDING')) || [];
+      const orders = await ordersActions.getOrders(ctx.user, 'PENDING');
+
+      // getOrders returns undefined when the query itself failed (already
+      // logged). Bail out instead of telling the user they have no orders,
+      // which would otherwise leave their pending orders silently uncanceled.
+      if (orders === undefined) return;
 
       if (orders.length === 0) {
         return await messages.notOrdersMessage(ctx);


### PR DESCRIPTION
## Summary

Fixes the bug where a buyer running `/cancelall` could cancel a `sell` order that was still waiting for the seller to pay the hold invoice (`WAITING_PAYMENT`), trapping the seller's funds in LND.

`/cancelall` now **only cancels `PENDING` orders** (published orders nobody has taken yet). Orders that are already being taken (`WAITING_PAYMENT` / `WAITING_BUYER_INVOICE`) are simply ignored — the command always runs and never blocks on them. Those orders must be handled individually with `/cancel` or through a dispute.

Closes #829

## Problem

The `/cancelall` handler collected orders in three states (`PENDING`, `WAITING_BUYER_INVOICE`, `WAITING_PAYMENT`) and tried to cancel all of them, with special-case hold invoice logic inside the loop. The case `sell` + `WAITING_PAYMENT` was not handled, so the order fell through to the generic `CANCELED` block:

- The hold invoice was **not** canceled on LND
- The seller received **no** notification

If the seller then paid the invoice, `subscribeToInvoice` found the order already `CANCELED` and did nothing, leaving the funds permanently trapped:

```
error: Order status is not WAITING_PAYMENT on subscribeToInvoice. Actual status: CANCELED
```

## Changes

- **`bot/start.ts`** — `/cancelall` now only fetches and cancels `PENDING` orders. Removed the per-order hold invoice logic from the loop (no longer needed, since pending orders have no locked funds). In-progress orders are left untouched and do not block the command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “cancel all” action to only affect pending orders.
  * Prevented cancellation flows from applying to orders in other waiting states, reducing unintended invoice-related actions.
  * Kept the same behavior when no pending orders are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->