### PR TITLE
fix: restore sats volume in fixed-price order title (regression from …

### DIFF
--- a/bot/ordersActions.ts
+++ b/bot/ordersActions.ts
@@ -248,7 +248,14 @@ const buildDescription = (
 
     const ageInDays = getUserAge(user);
 
-    const firstLine = getOrderTitleMessage(user, type, i18n);
+    const firstLine = getOrderTitleMessage(
+      user,
+      type,
+      amount,
+      fiatCode,
+      priceFromAPI,
+      i18n,
+    );
 
     let description: string = `${firstLine}\n`;
     description += i18n.t('for') + ` ${currencyString}\n`;
@@ -269,19 +276,30 @@ const buildDescription = (
 const getOrderTitleMessage = (
   user: UserDocument,
   type: string,
+  orderAmount: number,
+  fiatCode: string,
+  priceFromAPI: boolean,
   i18n: I18nContext,
 ) => {
   const isSell = type === 'sell';
+  // Fixed-price orders show the sats volume in the title; market-price orders
+  // don't, since the sats amount is not known until the order is taken.
+  const amount = priceFromAPI ? '' : numberFormat(fiatCode, orderAmount);
 
-  // Guard Clause: The user DOES want to show their name, we resolve and leave.
+  let title: string;
   if (user.show_username) {
-    return isSell
-      ? i18n.t('showusername_selling_sats', { username: user.username })
-      : i18n.t('showusername_buying_sats', { username: user.username });
+    title = isSell
+      ? i18n.t('showusername_selling_sats', { username: user.username, amount })
+      : i18n.t('showusername_buying_sats', { username: user.username, amount });
+  } else {
+    title = isSell
+      ? i18n.t('selling_sats', { amount })
+      : i18n.t('buying_sats', { amount });
   }
 
-  // The user DOES NOT want to show their name.
-  return isSell ? i18n.t('selling_sats') : i18n.t('buying_sats');
+  // Collapse any double spaces left when amount is empty (market orders) so the
+  // result is clean regardless of where translators place the ${amount} slot.
+  return title.replace(/\s+/g, ' ').trim();
 };
 
 const getOrder = async (

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -452,11 +452,11 @@ pending_payment_failed_to_admin: |
   Zahlungsversuche: ${attempts}
 selling: Verkaufe
 buying: Kaufe
-selling_sats: Verkaufe Sats
-buying_sats: Kaufe Sats
+selling_sats: 'Verkaufe ${amount} Sats'
+buying_sats: 'Kaufe ${amount} Sats'
 receive_payment: Zahlung erhalten
-showusername_buying_sats: '@${username} kauft Sats'
-showusername_selling_sats: '@${username} verkauft Sats'
+showusername_buying_sats: '@${username} kauft ${amount} Sats'
+showusername_selling_sats: '@${username} verkauft ${amount} Sats'
 pay: Bezahlen
 is: ist
 trading_volume: 'Handelsvolumen: ${Volumen} Sats'

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -459,10 +459,10 @@ pending_payment_failed_to_admin: |
   Payment attempts: ${attempts}
 selling: Selling
 buying: Buying
-selling_sats: Selling sats
-buying_sats: Buying sats
-showusername_selling_sats: '@${username} is selling sats'
-showusername_buying_sats: '@${username} is buying sats'
+selling_sats: 'Selling ${amount} sats'
+buying_sats: 'Buying ${amount} sats'
+showusername_selling_sats: '@${username} is selling ${amount} sats'
+showusername_buying_sats: '@${username} is buying ${amount} sats'
 receive_payment: Receive payment
 pay: Pay
 is: is

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -454,10 +454,10 @@ pending_payment_failed_to_admin: |
   Intento de pago: ${attempts}
 selling: Vendiendo
 buying: Comprando
-selling_sats: Vendiendo sats
-buying_sats: Comprando sats
-showusername_buying_sats: '@${username} está comprando sats'
-showusername_selling_sats: '@${username} está vendiendo sats'
+selling_sats: 'Vendiendo ${amount} sats'
+buying_sats: 'Comprando ${amount} sats'
+showusername_buying_sats: '@${username} está comprando ${amount} sats'
+showusername_selling_sats: '@${username} está vendiendo ${amount} sats'
 receive_payment: Recibo pago
 pay: Pago
 is: está

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -535,14 +535,14 @@ pending_payment_failed_to_admin: |
   تعداد تلاش‌های پرداخت: ${attempts}
 selling: فروختن
 buying: خریدن
-selling_sats: فروش ساتوشی
-buying_sats: خرید ساتوشی
+selling_sats: 'فروش ${amount} ساتوشی'
+buying_sats: 'خرید ${amount} ساتوشی'
 receive_payment: دریافت وجه
 pay: پرداخت
 is: هست
 trading_volume: 'حجم معاملات: ${volume} sat'
-showusername_buying_sats: '@${username} در حال خرید ساتوشی است'
-showusername_selling_sats: '@${username} در حال فروش ساتوشی است'
+showusername_buying_sats: '@${username} در حال خرید ${amount} ساتوشی است'
+showusername_selling_sats: '@${username} در حال فروش ${amount} ساتوشی است'
 satoshis: ساتوشی‌ها
 by: توسط
 rate: نرخ

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -451,11 +451,11 @@ pending_payment_failed_to_admin: |
   Tentatives de paiement : ${attempts}
 selling: Vente
 buying: Achat
-selling_sats: Vente de sats
-buying_sats: Achat de sats
+selling_sats: 'Vente de ${amount} sats'
+buying_sats: 'Achat de ${amount} sats'
 receive_payment: Réception du paiement
-showusername_buying_sats: "@${username} achète des sats"
-showusername_selling_sats: "@${username} vend des sats"
+showusername_buying_sats: "@${username} achète ${amount} sats"
+showusername_selling_sats: "@${username} vend ${amount} sats"
 pay: Payer
 is: est
 trading_volume: 'Volume de transactions : ${volume} sats'

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -449,14 +449,14 @@ pending_payment_failed_to_admin: |
   Payment attempts: ${attempts}
 selling: Vendita
 buying: Acquisto
-selling_sats: Vendita sats
-buying_sats: Acquisto sats
+selling_sats: 'Vendita ${amount} sats'
+buying_sats: 'Acquisto ${amount} sats'
 receive_payment: Ricezione del pagamento
 pay: Paga
 is: è
 trading_volume: 'Volume scambio: ${volume} sats'
-showusername_buying_sats: '@${username} sta comprando sats'
-showusername_selling_sats: '@${username} sta vendendo sats'
+showusername_buying_sats: '@${username} sta comprando ${amount} sats'
+showusername_selling_sats: '@${username} sta vendendo ${amount} sats'
 satoshis: satoshi
 by: da
 rate: Valutazione

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -449,14 +449,14 @@ pending_payment_failed_to_admin: |
 
 selling: 팝니다
 buying: 삽니다
-selling_sats: sats 판매
-buying_sats: sats 구매
+selling_sats: '${amount} sats 판매'
+buying_sats: '${amount} sats 구매'
 receive_payment: 입금
 pay: 결제
 is: is
 trading_volume: '거래량: ${volume} sats'
-showusername_buying_sats: '@${username} 님이 sats를 구매합니다'
-showusername_selling_sats: '@${username} 님이 sats를 판매합니다'
+showusername_buying_sats: '@${username} 님이 ${amount} sats를 구매합니다'
+showusername_selling_sats: '@${username} 님이 ${amount} sats를 판매합니다'
 satoshis: 사토시
 by: 방법 - 
 rate: 환율

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -451,12 +451,12 @@ pending_payment_failed_to_admin: |
   Tentativas de pagamento: ${attempts}
 selling: Vendendo
 buying: Comprando
-selling_sats: Vendendo sats
-buying_sats: Comprando sats
+selling_sats: 'Vendendo ${amount} sats'
+buying_sats: 'Comprando ${amount} sats'
 receive_payment: Receber pagamento
 pay: Pagar
-showusername_buying_sats: '@${username} está comprando sats'
-showusername_selling_sats: '@${username} está vendendo sats'
+showusername_buying_sats: '@${username} está comprando ${amount} sats'
+showusername_selling_sats: '@${username} está vendendo ${amount} sats'
 is: é
 trading_volume: 'Volume de negócios: ${volume} sats'
 satoshis: satoshis

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -452,11 +452,11 @@ pending_payment_failed_to_admin: |
   Попытка оплаты: ${attempts}
 selling: Продаю
 buying: Покупаю
-selling_sats: Продажа сат
-buying_sats: Покупка сат
+selling_sats: 'Продажа ${amount} сат'
+buying_sats: 'Покупка ${amount} сат'
 receive_payment: Расчет
-showusername_buying_sats: '@${username} покупает саты'
-showusername_selling_sats: '@${username} продает саты'
+showusername_buying_sats: '@${username} покупает ${amount} саты'
+showusername_selling_sats: '@${username} продает ${amount} саты'
 pay: Расчет
 is: Я
 trading_volume: 'Обьем торгов: ${volume} сат'

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -449,14 +449,14 @@ pending_payment_failed_to_admin: |
   Спроб оплати: ${attempts}
 selling: Продаю
 buying: Купую
-selling_sats: Продаж сатоші
-buying_sats: Купівля сатоші
+selling_sats: 'Продаж ${amount} сатоші'
+buying_sats: 'Купівля ${amount} сатоші'
 receive_payment: Розрахунок
 pay: Оплата
 is: є
 trading_volume: 'Обсяг торгів: ${volume} сат'
-showusername_buying_sats: '@${username} купує сатоші'
-showusername_selling_sats: '@${username} продає сатоші'
+showusername_buying_sats: '@${username} купує ${amount} сатоші'
+showusername_selling_sats: '@${username} продає ${amount} сатоші'
 satoshis: сатоші
 by: за допомогою
 rate: Kурс


### PR DESCRIPTION
# Fixed-price orders hide the sats volume, making them look mispriced vs market rate (regression from #770)

Fixes #850 

## Summary

Users are reporting that for some orders (notably CUP, sometimes VES) the bot asks the buyer for ~10–20% fewer sats than the market rate on yadio suggests. Example from a report:

- Offer: selling sats for **7,560 CUP**, shown **Price: 45,542,168.67**
- Bot asks buyer for an invoice of **16,600 sats**
- yadio market rate for 7,560 CUP ≈ **21,000 sats**
- Apparent gap: ~20%

The bot is **not** miscalculating. The order is a **fixed-price** order:
`7,560 / 45,542,168 × 100,000,000 ≈ 16,600 sats`, which is exactly what the bot asks. The gap is simply the difference between the seller's fixed price (~45.5M CUP/BTC) and the current market rate (~36M CUP/BTC).

The real problem is **transparency**: fixed-price offers no longer display the sats volume, so they look almost identical to market-rate offers. Buyers assume market rate, check yadio, and are surprised. This started after PR #770 was deployed ("since last night"), and shows up most on CUP/VES because those have the widest spread between fixed listings and the yadio rate.

**Reproduced locally with an ARS fixed-price order (`/buy 1303 1303 ars nx`):** the offer showed `Precio: 100.000.000` (confirming it is a fixed order) but the title read `Comprando sats` with no amount — identical to a market-rate order. A market order (`/buy 0 1304 ars nx`) showed the same title but with `Tasa: yadio` instead of a `Precio:` line.

## Root cause

PR #770 ("Improve i18n flexibility for showusername order sentences", commit `66e0004`).

Before #770, `buildDescription()` in `bot/ordersActions.ts` printed the sats amount in the first line for fixed-price orders:

```ts
const action = type === 'sell' ? i18n.t('selling') : i18n.t('buying');
let amountText = `${numberFormat(fiatCode, amount)} `; // sats quantity
if (priceFromAPI) {
  amountText = ''; // hidden only for market-price orders
}
let description = `${username}${action} ${amountText}` + i18n.t('sats') + `\n`;
```

So a fixed order clearly read `Selling 100 sats`, while a market order read `Selling sats`.

#770 moved the whole sentence into single-template strings (`selling_sats`, `buying_sats`, `showusername_selling_sats`, ...) that only accept `{username}`, to give translators freedom to write natural sentences. In doing so it **dropped the `${amount}` interpolation**. The new `getOrderTitleMessage()` never printed the sats amount:

```ts
return isSell ? i18n.t('selling_sats') : i18n.t('buying_sats'); // no amount, ever
```

So #770 did not change any price/amount math — it removed the sats-volume display that made fixed-price (off-market) orders obvious to buyers. The result is that fixed orders now look like market orders, and the fixed-vs-market spread becomes an invisible surprise.

## Fix

Reintroduce the sats volume as a single `${amount}` variable inside the existing title templates, instead of adding a parallel set of keys:

- `bot/ordersActions.ts` → `getOrderTitleMessage()` now receives `amount`, `fiatCode` and `priceFromAPI`. It fills `${amount}` with `numberFormat(fiatCode, amount)` for fixed orders and with an empty string for market orders, then collapses whitespace (`.replace(/\s+/g, ' ').trim()`) so the market case never leaves a double space regardless of where translators place the slot.
- `locales/*.yaml` (all 10 languages) → the same 4 keys now carry a `${amount}` placeholder. No new keys added.

Resulting behavior:

- **Fixed-price order** (`price_from_api === false`): `Selling 1,000 sats` / `@user is selling 1,000 sats`.
- **Market-price order** (`price_from_api === true`): `Selling sats` / `@user is selling sats` (unchanged, no double space).

## Notes

- This is **not** a separate market-rate bug. The CUP/VES "10–20% difference" reports are the fixed-vs-market spread becoming invisible once the sats volume stopped being shown; restoring it makes fixed orders recognizable again.

## Affected files

- `bot/ordersActions.ts` (`buildDescription`, `getOrderTitleMessage`)
- `locales/*.yaml` (all languages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order and notification text now shows the traded amount more consistently, including username-based sale/buy messages.

* **Bug Fixes**
  * Market-price orders now display without an amount in titles, while fixed-price orders show a formatted fiat amount.
  * Improved spacing and formatting in order titles for cleaner display.

* **Localization**
  * Updated translated order strings across multiple languages to include dynamic amount placeholders and match the new display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->