### PR TITLE
fix: show sats amount on fixed orders

### DIFF
--- a/bot/ordersActions.ts
+++ b/bot/ordersActions.ts
@@ -400,4 +400,10 @@ const getNewRangeOrderPayload = async (order: IOrder) => {
   }
 };
 
-export { createOrder, getOrder, getOrders, getNewRangeOrderPayload };
+export {
+  createOrder,
+  getOrder,
+  getOrders,
+  getNewRangeOrderPayload,
+  getOrderTitleMessage,
+};

--- a/bot/ordersActions.ts
+++ b/bot/ordersActions.ts
@@ -248,7 +248,14 @@ const buildDescription = (
 
     const ageInDays = getUserAge(user);
 
-    const firstLine = getOrderTitleMessage(user, type, i18n);
+    const firstLine = getOrderTitleMessage(
+      user,
+      type,
+      amount,
+      fiatCode,
+      priceFromAPI,
+      i18n,
+    );
 
     let description: string = `${firstLine}\n`;
     description += i18n.t('for') + ` ${currencyString}\n`;
@@ -269,19 +276,34 @@ const buildDescription = (
 const getOrderTitleMessage = (
   user: UserDocument,
   type: string,
+  amount: number,
+  fiatCode: string,
+  priceFromAPI: boolean,
   i18n: I18nContext,
 ) => {
   const isSell = type === 'sell';
 
+  // For fixed orders we show the sats amount; for market/range orders
+  // (priceFromAPI, amount === 0) the amount is omitted.
+  const amountText = priceFromAPI ? '' : `${numberFormat(fiatCode, amount)} `;
+
   // Guard Clause: The user DOES want to show their name, we resolve and leave.
   if (user.show_username) {
     return isSell
-      ? i18n.t('showusername_selling_sats', { username: user.username })
-      : i18n.t('showusername_buying_sats', { username: user.username });
+      ? i18n.t('showusername_selling_sats', {
+          username: user.username,
+          amount: amountText,
+        })
+      : i18n.t('showusername_buying_sats', {
+          username: user.username,
+          amount: amountText,
+        });
   }
 
   // The user DOES NOT want to show their name.
-  return isSell ? i18n.t('selling_sats') : i18n.t('buying_sats');
+  return isSell
+    ? i18n.t('selling_sats', { amount: amountText })
+    : i18n.t('buying_sats', { amount: amountText });
 };
 
 const getOrder = async (

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -452,11 +452,11 @@ pending_payment_failed_to_admin: |
   Zahlungsversuche: ${attempts}
 selling: Verkaufe
 buying: Kaufe
-selling_sats: Verkaufe Sats
-buying_sats: Kaufe Sats
+selling_sats: 'Verkaufe ${amount}Sats'
+buying_sats: 'Kaufe ${amount}Sats'
 receive_payment: Zahlung erhalten
-showusername_buying_sats: '@${username} kauft Sats'
-showusername_selling_sats: '@${username} verkauft Sats'
+showusername_buying_sats: '@${username} kauft ${amount}Sats'
+showusername_selling_sats: '@${username} verkauft ${amount}Sats'
 pay: Bezahlen
 is: ist
 trading_volume: 'Handelsvolumen: ${Volumen} Sats'

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -459,10 +459,10 @@ pending_payment_failed_to_admin: |
   Payment attempts: ${attempts}
 selling: Selling
 buying: Buying
-selling_sats: Selling sats
-buying_sats: Buying sats
-showusername_selling_sats: '@${username} is selling sats'
-showusername_buying_sats: '@${username} is buying sats'
+selling_sats: 'Selling ${amount}sats'
+buying_sats: 'Buying ${amount}sats'
+showusername_selling_sats: '@${username} is selling ${amount}sats'
+showusername_buying_sats: '@${username} is buying ${amount}sats'
 receive_payment: Receive payment
 pay: Pay
 is: is

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -454,10 +454,10 @@ pending_payment_failed_to_admin: |
   Intento de pago: ${attempts}
 selling: Vendiendo
 buying: Comprando
-selling_sats: Vendiendo sats
-buying_sats: Comprando sats
-showusername_buying_sats: '@${username} está comprando sats'
-showusername_selling_sats: '@${username} está vendiendo sats'
+selling_sats: 'Vendiendo ${amount}sats'
+buying_sats: 'Comprando ${amount}sats'
+showusername_buying_sats: '@${username} está comprando ${amount}sats'
+showusername_selling_sats: '@${username} está vendiendo ${amount}sats'
 receive_payment: Recibo pago
 pay: Pago
 is: está

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -535,14 +535,14 @@ pending_payment_failed_to_admin: |
   تعداد تلاش‌های پرداخت: ${attempts}
 selling: فروختن
 buying: خریدن
-selling_sats: فروش ساتوشی
-buying_sats: خرید ساتوشی
+selling_sats: 'فروش ${amount}ساتوشی'
+buying_sats: 'خرید ${amount}ساتوشی'
 receive_payment: دریافت وجه
 pay: پرداخت
 is: هست
 trading_volume: 'حجم معاملات: ${volume} sat'
-showusername_buying_sats: '@${username} در حال خرید ساتوشی است'
-showusername_selling_sats: '@${username} در حال فروش ساتوشی است'
+showusername_buying_sats: '@${username} در حال خرید ${amount}ساتوشی است'
+showusername_selling_sats: '@${username} در حال فروش ${amount}ساتوشی است'
 satoshis: ساتوشی‌ها
 by: توسط
 rate: نرخ

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -451,11 +451,11 @@ pending_payment_failed_to_admin: |
   Tentatives de paiement : ${attempts}
 selling: Vente
 buying: Achat
-selling_sats: Vente de sats
-buying_sats: Achat de sats
+selling_sats: 'Vente de ${amount}sats'
+buying_sats: 'Achat de ${amount}sats'
 receive_payment: Réception du paiement
-showusername_buying_sats: "@${username} achète des sats"
-showusername_selling_sats: "@${username} vend des sats"
+showusername_buying_sats: "@${username} achète ${amount}sats"
+showusername_selling_sats: "@${username} vend ${amount}sats"
 pay: Payer
 is: est
 trading_volume: 'Volume de transactions : ${volume} sats'

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -449,14 +449,14 @@ pending_payment_failed_to_admin: |
   Payment attempts: ${attempts}
 selling: Vendita
 buying: Acquisto
-selling_sats: Vendita sats
-buying_sats: Acquisto sats
+selling_sats: 'Vendita ${amount}sats'
+buying_sats: 'Acquisto ${amount}sats'
 receive_payment: Ricezione del pagamento
 pay: Paga
 is: è
 trading_volume: 'Volume scambio: ${volume} sats'
-showusername_buying_sats: '@${username} sta comprando sats'
-showusername_selling_sats: '@${username} sta vendendo sats'
+showusername_buying_sats: '@${username} sta comprando ${amount}sats'
+showusername_selling_sats: '@${username} sta vendendo ${amount}sats'
 satoshis: satoshi
 by: da
 rate: Valutazione

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -449,14 +449,14 @@ pending_payment_failed_to_admin: |
 
 selling: 팝니다
 buying: 삽니다
-selling_sats: sats 판매
-buying_sats: sats 구매
+selling_sats: '${amount}sats 판매'
+buying_sats: '${amount}sats 구매'
 receive_payment: 입금
 pay: 결제
 is: is
 trading_volume: '거래량: ${volume} sats'
-showusername_buying_sats: '@${username} 님이 sats를 구매합니다'
-showusername_selling_sats: '@${username} 님이 sats를 판매합니다'
+showusername_buying_sats: '@${username} 님이 ${amount}sats를 구매합니다'
+showusername_selling_sats: '@${username} 님이 ${amount}sats를 판매합니다'
 satoshis: 사토시
 by: 방법 - 
 rate: 환율

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -451,12 +451,12 @@ pending_payment_failed_to_admin: |
   Tentativas de pagamento: ${attempts}
 selling: Vendendo
 buying: Comprando
-selling_sats: Vendendo sats
-buying_sats: Comprando sats
+selling_sats: 'Vendendo ${amount}sats'
+buying_sats: 'Comprando ${amount}sats'
 receive_payment: Receber pagamento
 pay: Pagar
-showusername_buying_sats: '@${username} está comprando sats'
-showusername_selling_sats: '@${username} está vendendo sats'
+showusername_buying_sats: '@${username} está comprando ${amount}sats'
+showusername_selling_sats: '@${username} está vendendo ${amount}sats'
 is: é
 trading_volume: 'Volume de negócios: ${volume} sats'
 satoshis: satoshis

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -452,11 +452,11 @@ pending_payment_failed_to_admin: |
   Попытка оплаты: ${attempts}
 selling: Продаю
 buying: Покупаю
-selling_sats: Продажа сат
-buying_sats: Покупка сат
+selling_sats: 'Продажа ${amount}сат'
+buying_sats: 'Покупка ${amount}сат'
 receive_payment: Расчет
-showusername_buying_sats: '@${username} покупает саты'
-showusername_selling_sats: '@${username} продает саты'
+showusername_buying_sats: '@${username} покупает ${amount}саты'
+showusername_selling_sats: '@${username} продает ${amount}саты'
 pay: Расчет
 is: Я
 trading_volume: 'Обьем торгов: ${volume} сат'

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -449,14 +449,14 @@ pending_payment_failed_to_admin: |
   Спроб оплати: ${attempts}
 selling: Продаю
 buying: Купую
-selling_sats: Продаж сатоші
-buying_sats: Купівля сатоші
+selling_sats: 'Продаж ${amount}сатоші'
+buying_sats: 'Купівля ${amount}сатоші'
 receive_payment: Розрахунок
 pay: Оплата
 is: є
 trading_volume: 'Обсяг торгів: ${volume} сат'
-showusername_buying_sats: '@${username} купує сатоші'
-showusername_selling_sats: '@${username} продає сатоші'
+showusername_buying_sats: '@${username} купує ${amount}сатоші'
+showusername_selling_sats: '@${username} продає ${amount}сатоші'
 satoshis: сатоші
 by: за допомогою
 rate: Kурс

--- a/tests/bot/ordersActions.spec.ts
+++ b/tests/bot/ordersActions.spec.ts
@@ -1,0 +1,98 @@
+const { expect } = require('chai');
+const { I18n } = require('@grammyjs/i18n');
+const { getOrderTitleMessage } = require('../../bot/ordersActions');
+
+// Real i18n context so the test exercises the actual locale strings and
+// their ${amount} interpolation (the part that regressed in PR #770).
+const i18nCtx = new I18n({
+  locale: 'en',
+  defaultLanguageOnMissing: true,
+  directory: 'locales',
+}).createContext('en', {});
+
+describe('getOrderTitleMessage', () => {
+  const anonymousUser: any = { username: 'alice', show_username: false };
+  const publicUser: any = { username: 'alice', show_username: true };
+
+  describe('fixed orders (amount set, price not from API)', () => {
+    it('shows the sats amount when selling', () => {
+      const title = getOrderTitleMessage(
+        anonymousUser,
+        'sell',
+        100,
+        'USD',
+        false,
+        i18nCtx,
+      );
+
+      expect(title).to.equal('Selling 100 sats');
+    });
+
+    it('shows the sats amount when buying', () => {
+      const title = getOrderTitleMessage(
+        anonymousUser,
+        'buy',
+        100,
+        'USD',
+        false,
+        i18nCtx,
+      );
+
+      expect(title).to.equal('Buying 100 sats');
+    });
+
+    it('shows the username and the sats amount when the user shows their name', () => {
+      const title = getOrderTitleMessage(
+        publicUser,
+        'sell',
+        100,
+        'USD',
+        false,
+        i18nCtx,
+      );
+
+      expect(title).to.equal('@alice is selling 100 sats');
+    });
+  });
+
+  describe('market/range orders (amount is 0, price from API)', () => {
+    it('omits the amount when selling', () => {
+      const title = getOrderTitleMessage(
+        anonymousUser,
+        'sell',
+        0,
+        'USD',
+        true,
+        i18nCtx,
+      );
+
+      expect(title).to.equal('Selling sats');
+    });
+
+    it('omits the amount when buying', () => {
+      const title = getOrderTitleMessage(
+        anonymousUser,
+        'buy',
+        0,
+        'USD',
+        true,
+        i18nCtx,
+      );
+
+      expect(title).to.equal('Buying sats');
+    });
+
+    it('shows the username but omits the amount when the user shows their name', () => {
+      const title = getOrderTitleMessage(
+        publicUser,
+        'buy',
+        0,
+        'USD',
+        true,
+        i18nCtx,
+      );
+
+      expect(title).to.equal('@alice is buying sats');
+    });
+  });
+});

--- a/tests/bot/ordersActions.spec.ts
+++ b/tests/bot/ordersActions.spec.ts
@@ -1,6 +1,10 @@
+import { getOrderTitleMessage } from '../../bot/ordersActions';
+
+// chai v4 ships no types and @grammyjs/i18n's typed Config rejects the
+// locale/directory options, so both are required CommonJS-style, matching
+// every other spec and the production I18n usage in bot/ordersActions.ts.
 const { expect } = require('chai');
 const { I18n } = require('@grammyjs/i18n');
-const { getOrderTitleMessage } = require('../../bot/ordersActions');
 
 // Real i18n context so the test exercises the actual locale strings and
 // their ${amount} interpolation (the part that regressed in PR #770).


### PR DESCRIPTION
PR #770 moved the order title into a single i18n string and dropped the sats amount, so fixed orders showed "Selling sats" instead of "Selling 100 sats".

Restores the amount via a ${amount} placeholder in the locale keys (all languages) and computes it in getOrderTitleMessage: shown for fixed orders, omitted for market/range orders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order status notifications now display the satoshi amount for buy/sell.
  * Username-specific variants show both the username and the satoshi amount.
  * Amount display is adjusted for cases where pricing is sourced from the API.
* **Localization**
  * Updated buy/sell translated strings across supported languages to include `${amount}` consistently (including username variants).
* **Tests**
  * Added automated coverage to verify title formatting for fixed vs. range/market scenarios and conditional username inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->