### PR TITLE
fix: unify sats wording in Russian order title keys

### DIFF
--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -455,8 +455,8 @@ buying: Покупаю
 selling_sats: 'Продажа ${amount}сат'
 buying_sats: 'Покупка ${amount}сат'
 receive_payment: Расчет
-showusername_buying_sats: '@${username} покупает ${amount}саты'
-showusername_selling_sats: '@${username} продает ${amount}саты'
+showusername_buying_sats: '@${username} покупает ${amount}сат'
+showusername_selling_sats: '@${username} продает ${amount}сат'
 pay: Расчет
 is: Я
 trading_volume: 'Обьем торгов: ${volume} сат'


### PR DESCRIPTION
Closes #856

The anonymous order title keys in `ru.yaml` use "сат" while the `showusername_*` variants used "саты", so the channel showed inconsistent wording depending on whether the user displays their name.

This unifies all four keys on "сат", matching `selling_sats`/`buying_sats` and `trading_volume`, and reads naturally with an interpolated amount ("покупает 100 сат").

Translation-only change, no code involved.

## Test plan
- [x] `npm run lint` passes (YAML untouched by ESLint, sanity only)
- [x] Wording check by a native Russian speaker would be welcome before merge