### PR TITLE
fix: make numberFormat always return a string

### DIFF
--- a/tests/util/index.spec.ts
+++ b/tests/util/index.spec.ts
@@ -42,29 +42,38 @@ describe('Utility Functions', () => {
   });
 
   describe('numberFormat', () => {
-    it('should return false for invalid currency code', () => {
+    it('returns the plain number as string for an invalid currency code', () => {
       const result = numberFormat('INVALID', 100);
-      expect(result).to.equal(false);
+      expect(result).to.equal('100');
     });
 
-    it('should return original number if no locale found', () => {
+    it('formats the number using the currency locale', () => {
       const result = numberFormat('USD', 1234.56);
-      expect(result).to.not.be.false;
+      expect(result).to.equal('1,234.56');
     });
 
-    it('should return original number for NaN input', () => {
+    it('returns a string for NaN input', () => {
       const result = numberFormat('USD', NaN);
-      expect(result).to.be.NaN;
+      expect(result).to.equal('NaN');
     });
 
-    it('should handle zero correctly', () => {
+    it('handles zero correctly', () => {
       const result = numberFormat('USD', 0);
-      expect(result).to.not.be.false;
+      expect(result).to.equal('0');
     });
 
-    it('should handle negative numbers', () => {
+    it('handles negative numbers', () => {
       const result = numberFormat('USD', -100);
-      expect(result).to.not.be.false;
+      expect(result).to.equal('-100');
+    });
+
+    it('always returns a string', () => {
+      const results = [
+        numberFormat('INVALID', 100),
+        numberFormat('USD', 1000),
+        numberFormat('USD', NaN),
+      ];
+      results.forEach(result => expect(result).to.be.a('string'));
     });
   });
 

--- a/util/index.ts
+++ b/util/index.ts
@@ -63,18 +63,17 @@ const plural = (n: number): string => {
 exports.plural = plural;
 
 // This function formats a number to locale strings.
-// If Iso code or locale code doesn´t exist, the function will return a number without format.
-const numberFormat = (code: string, number: number) => {
-  if (!isIso4217(code)) return false;
+// If Iso code or locale code doesn´t exist, the function will return the number as a plain string.
+const numberFormat = (code: string, number: number): string => {
+  if (!isIso4217(code)) return String(number);
 
-  if (!currencies[code]) return number;
+  if (!currencies[code]) return String(number);
 
   const locale = currencies[code].locale;
-  const numberToLocaleString = Intl.NumberFormat(locale);
 
-  if (!locale || isNaN(number)) return number;
+  if (!locale || isNaN(number)) return String(number);
 
-  return numberToLocaleString.format(number);
+  return Intl.NumberFormat(locale).format(number);
 };
 
 // This function checks if the current buyer and seller were doing circular operations


### PR DESCRIPTION
Closes #855

`numberFormat` had an inconsistent return type (`false | number | string`), and its results are interpolated directly into user-facing strings (order descriptions, order titles, trading volume). Nothing breaks today because every caller validates the currency first, but that invariant was implicit — the first future caller that skips the `getCurrency` check would publish a title like "Selling false sats" to the order channel.

## Changes

- `numberFormat` now has an explicit `: string` return type and falls back to `String(number)` in every non-formattable case (invalid ISO-4217 code, unknown currency, missing locale, NaN).
- Updated `tests/util/index.spec.ts` to the new contract (TDD: tests updated first and confirmed failing, then the fix), including a new case asserting the return is always a string.

All 19 existing call sites (`bot/ordersActions.ts`, `bot/messages.ts`) already treat the result as display text; none compares against `false`, so no behavior changes for valid inputs.

Re: [the suggestion](https://github.com/lnp2pBot/bot/issues/855#issuecomment-4869258412) to enable `@typescript-eslint/explicit-function-return-type` — measured it: 381 warnings repo-wide today, so it's a separate effort; this PR adds the explicit return type to the function at hand. Follow-up discussion in #855.

## Test plan
- [x] Updated tests fail against old implementation (RED) and pass against new one (GREEN)
- [x] Full suite: 151 passing, 0 failing
- [x] `npm run lint` clean
- [x] `npx tsc` full build clean