### PR TITLE
refactor: split order title i18n keys into no-amount / with-amount variants

### DIFF
--- a/bot/ordersActions.ts
+++ b/bot/ordersActions.ts
@@ -47,6 +47,14 @@ interface BuildDescriptionArguments {
   currency: IFiat;
 }
 
+interface OrderTitleArguments {
+  user: UserDocument;
+  type: string;
+  amount: number;
+  fiatCode: string;
+  priceFromAPI: boolean;
+}
+
 interface FiatAmountData {
   fiat_amount?: number;
   min_amount?: number;
@@ -248,14 +256,13 @@ const buildDescription = (
 
     const ageInDays = getUserAge(user);
 
-    const firstLine = getOrderTitleMessage(
+    const firstLine = getOrderTitleMessage(i18n, {
       user,
       type,
       amount,
       fiatCode,
       priceFromAPI,
-      i18n,
-    );
+    });
 
     let description: string = `${firstLine}\n`;
     description += i18n.t('for') + ` ${currencyString}\n`;
@@ -274,36 +281,38 @@ const buildDescription = (
 };
 
 const getOrderTitleMessage = (
-  user: UserDocument,
-  type: string,
-  amount: number,
-  fiatCode: string,
-  priceFromAPI: boolean,
   i18n: I18nContext,
+  { user, type, amount, fiatCode, priceFromAPI }: OrderTitleArguments,
 ) => {
   const isSell = type === 'sell';
 
-  // For fixed orders we show the sats amount; for market/range orders
-  // (priceFromAPI, amount === 0) the amount is omitted.
-  const amountText = priceFromAPI ? '' : `${numberFormat(fiatCode, amount)} `;
-
-  // Guard Clause: The user DOES want to show their name, we resolve and leave.
-  if (user.show_username) {
-    return isSell
-      ? i18n.t('showusername_selling_sats', {
-          username: user.username,
-          amount: amountText,
-        })
-      : i18n.t('showusername_buying_sats', {
-          username: user.username,
-          amount: amountText,
-        });
+  // Market and range orders take their price from the API and have no fixed
+  // sats amount at creation time, so their title shows no amount.
+  if (priceFromAPI) {
+    if (user.show_username) {
+      return isSell
+        ? i18n.t('showusername_selling_sats', { username: user.username })
+        : i18n.t('showusername_buying_sats', { username: user.username });
+    }
+    return isSell ? i18n.t('selling_sats') : i18n.t('buying_sats');
   }
 
-  // The user DOES NOT want to show their name.
+  // Fixed orders show the sats amount.
+  const formattedAmount = numberFormat(fiatCode, amount);
+  if (user.show_username) {
+    return isSell
+      ? i18n.t('showusername_selling_sats_with_amount', {
+          username: user.username,
+          amount: formattedAmount,
+        })
+      : i18n.t('showusername_buying_sats_with_amount', {
+          username: user.username,
+          amount: formattedAmount,
+        });
+  }
   return isSell
-    ? i18n.t('selling_sats', { amount: amountText })
-    : i18n.t('buying_sats', { amount: amountText });
+    ? i18n.t('selling_sats_with_amount', { amount: formattedAmount })
+    : i18n.t('buying_sats_with_amount', { amount: formattedAmount });
 };
 
 const getOrder = async (

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -452,11 +452,15 @@ pending_payment_failed_to_admin: |
   Zahlungsversuche: ${attempts}
 selling: Verkaufe
 buying: Kaufe
-selling_sats: 'Verkaufe ${amount}Sats'
-buying_sats: 'Kaufe ${amount}Sats'
+selling_sats: Verkaufe Sats
+selling_sats_with_amount: 'Verkaufe ${amount} Sats'
+buying_sats: Kaufe Sats
+buying_sats_with_amount: 'Kaufe ${amount} Sats'
 receive_payment: Zahlung erhalten
-showusername_buying_sats: '@${username} kauft ${amount}Sats'
-showusername_selling_sats: '@${username} verkauft ${amount}Sats'
+showusername_buying_sats: '@${username} kauft Sats'
+showusername_buying_sats_with_amount: '@${username} kauft ${amount} Sats'
+showusername_selling_sats: '@${username} verkauft Sats'
+showusername_selling_sats_with_amount: '@${username} verkauft ${amount} Sats'
 pay: Bezahlen
 is: ist
 trading_volume: 'Handelsvolumen: ${Volumen} Sats'

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -459,10 +459,14 @@ pending_payment_failed_to_admin: |
   Payment attempts: ${attempts}
 selling: Selling
 buying: Buying
-selling_sats: 'Selling ${amount}sats'
-buying_sats: 'Buying ${amount}sats'
-showusername_selling_sats: '@${username} is selling ${amount}sats'
-showusername_buying_sats: '@${username} is buying ${amount}sats'
+selling_sats: Selling sats
+selling_sats_with_amount: 'Selling ${amount} sats'
+buying_sats: Buying sats
+buying_sats_with_amount: 'Buying ${amount} sats'
+showusername_selling_sats: '@${username} is selling sats'
+showusername_selling_sats_with_amount: '@${username} is selling ${amount} sats'
+showusername_buying_sats: '@${username} is buying sats'
+showusername_buying_sats_with_amount: '@${username} is buying ${amount} sats'
 receive_payment: Receive payment
 pay: Pay
 is: is

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -454,10 +454,14 @@ pending_payment_failed_to_admin: |
   Intento de pago: ${attempts}
 selling: Vendiendo
 buying: Comprando
-selling_sats: 'Vendiendo ${amount}sats'
-buying_sats: 'Comprando ${amount}sats'
-showusername_buying_sats: '@${username} está comprando ${amount}sats'
-showusername_selling_sats: '@${username} está vendiendo ${amount}sats'
+selling_sats: Vendiendo sats
+selling_sats_with_amount: 'Vendiendo ${amount} sats'
+buying_sats: Comprando sats
+buying_sats_with_amount: 'Comprando ${amount} sats'
+showusername_buying_sats: '@${username} está comprando sats'
+showusername_buying_sats_with_amount: '@${username} está comprando ${amount} sats'
+showusername_selling_sats: '@${username} está vendiendo sats'
+showusername_selling_sats_with_amount: '@${username} está vendiendo ${amount} sats'
 receive_payment: Recibo pago
 pay: Pago
 is: está

--- a/locales/fa.yaml
+++ b/locales/fa.yaml
@@ -535,14 +535,18 @@ pending_payment_failed_to_admin: |
   تعداد تلاش‌های پرداخت: ${attempts}
 selling: فروختن
 buying: خریدن
-selling_sats: 'فروش ${amount}ساتوشی'
-buying_sats: 'خرید ${amount}ساتوشی'
+selling_sats: فروش ساتوشی
+selling_sats_with_amount: 'فروش ${amount} ساتوشی'
+buying_sats: خرید ساتوشی
+buying_sats_with_amount: 'خرید ${amount} ساتوشی'
 receive_payment: دریافت وجه
 pay: پرداخت
 is: هست
 trading_volume: 'حجم معاملات: ${volume} sat'
-showusername_buying_sats: '@${username} در حال خرید ${amount}ساتوشی است'
-showusername_selling_sats: '@${username} در حال فروش ${amount}ساتوشی است'
+showusername_buying_sats: '@${username} در حال خرید ساتوشی است'
+showusername_buying_sats_with_amount: '@${username} در حال خرید ${amount} ساتوشی است'
+showusername_selling_sats: '@${username} در حال فروش ساتوشی است'
+showusername_selling_sats_with_amount: '@${username} در حال فروش ${amount} ساتوشی است'
 satoshis: ساتوشی‌ها
 by: توسط
 rate: نرخ

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -451,11 +451,15 @@ pending_payment_failed_to_admin: |
   Tentatives de paiement : ${attempts}
 selling: Vente
 buying: Achat
-selling_sats: 'Vente de ${amount}sats'
-buying_sats: 'Achat de ${amount}sats'
+selling_sats: Vente de sats
+selling_sats_with_amount: 'Vente de ${amount} sats'
+buying_sats: Achat de sats
+buying_sats_with_amount: 'Achat de ${amount} sats'
 receive_payment: Réception du paiement
-showusername_buying_sats: "@${username} achète ${amount}sats"
-showusername_selling_sats: "@${username} vend ${amount}sats"
+showusername_buying_sats: "@${username} achète des sats"
+showusername_buying_sats_with_amount: "@${username} achète ${amount} sats"
+showusername_selling_sats: "@${username} vend des sats"
+showusername_selling_sats_with_amount: "@${username} vend ${amount} sats"
 pay: Payer
 is: est
 trading_volume: 'Volume de transactions : ${volume} sats'

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -449,14 +449,18 @@ pending_payment_failed_to_admin: |
   Payment attempts: ${attempts}
 selling: Vendita
 buying: Acquisto
-selling_sats: 'Vendita ${amount}sats'
-buying_sats: 'Acquisto ${amount}sats'
+selling_sats: Vendita sats
+selling_sats_with_amount: 'Vendita ${amount} sats'
+buying_sats: Acquisto sats
+buying_sats_with_amount: 'Acquisto ${amount} sats'
 receive_payment: Ricezione del pagamento
 pay: Paga
 is: è
 trading_volume: 'Volume scambio: ${volume} sats'
-showusername_buying_sats: '@${username} sta comprando ${amount}sats'
-showusername_selling_sats: '@${username} sta vendendo ${amount}sats'
+showusername_buying_sats: '@${username} sta comprando sats'
+showusername_buying_sats_with_amount: '@${username} sta comprando ${amount} sats'
+showusername_selling_sats: '@${username} sta vendendo sats'
+showusername_selling_sats_with_amount: '@${username} sta vendendo ${amount} sats'
 satoshis: satoshi
 by: da
 rate: Valutazione

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -449,14 +449,18 @@ pending_payment_failed_to_admin: |
 
 selling: 팝니다
 buying: 삽니다
-selling_sats: '${amount}sats 판매'
-buying_sats: '${amount}sats 구매'
+selling_sats: sats 판매
+selling_sats_with_amount: '${amount} sats 판매'
+buying_sats: sats 구매
+buying_sats_with_amount: '${amount} sats 구매'
 receive_payment: 입금
 pay: 결제
 is: is
 trading_volume: '거래량: ${volume} sats'
-showusername_buying_sats: '@${username} 님이 ${amount}sats를 구매합니다'
-showusername_selling_sats: '@${username} 님이 ${amount}sats를 판매합니다'
+showusername_buying_sats: '@${username} 님이 sats를 구매합니다'
+showusername_buying_sats_with_amount: '@${username} 님이 ${amount} sats를 구매합니다'
+showusername_selling_sats: '@${username} 님이 sats를 판매합니다'
+showusername_selling_sats_with_amount: '@${username} 님이 ${amount} sats를 판매합니다'
 satoshis: 사토시
 by: 방법 - 
 rate: 환율

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -451,12 +451,16 @@ pending_payment_failed_to_admin: |
   Tentativas de pagamento: ${attempts}
 selling: Vendendo
 buying: Comprando
-selling_sats: 'Vendendo ${amount}sats'
-buying_sats: 'Comprando ${amount}sats'
+selling_sats: Vendendo sats
+selling_sats_with_amount: 'Vendendo ${amount} sats'
+buying_sats: Comprando sats
+buying_sats_with_amount: 'Comprando ${amount} sats'
 receive_payment: Receber pagamento
 pay: Pagar
-showusername_buying_sats: '@${username} está comprando ${amount}sats'
-showusername_selling_sats: '@${username} está vendendo ${amount}sats'
+showusername_buying_sats: '@${username} está comprando sats'
+showusername_buying_sats_with_amount: '@${username} está comprando ${amount} sats'
+showusername_selling_sats: '@${username} está vendendo sats'
+showusername_selling_sats_with_amount: '@${username} está vendendo ${amount} sats'
 is: é
 trading_volume: 'Volume de negócios: ${volume} sats'
 satoshis: satoshis

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -452,11 +452,15 @@ pending_payment_failed_to_admin: |
   Попытка оплаты: ${attempts}
 selling: Продаю
 buying: Покупаю
-selling_sats: 'Продажа ${amount}сат'
-buying_sats: 'Покупка ${amount}сат'
+selling_sats: Продажа сат
+selling_sats_with_amount: 'Продажа ${amount} сат'
+buying_sats: Покупка сат
+buying_sats_with_amount: 'Покупка ${amount} сат'
 receive_payment: Расчет
-showusername_buying_sats: '@${username} покупает ${amount}сат'
-showusername_selling_sats: '@${username} продает ${amount}сат'
+showusername_buying_sats: '@${username} покупает сат'
+showusername_buying_sats_with_amount: '@${username} покупает ${amount} сат'
+showusername_selling_sats: '@${username} продает сат'
+showusername_selling_sats_with_amount: '@${username} продает ${amount} сат'
 pay: Расчет
 is: Я
 trading_volume: 'Обьем торгов: ${volume} сат'

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -449,14 +449,18 @@ pending_payment_failed_to_admin: |
   Спроб оплати: ${attempts}
 selling: Продаю
 buying: Купую
-selling_sats: 'Продаж ${amount}сатоші'
-buying_sats: 'Купівля ${amount}сатоші'
+selling_sats: Продаж сатоші
+selling_sats_with_amount: 'Продаж ${amount} сатоші'
+buying_sats: Купівля сатоші
+buying_sats_with_amount: 'Купівля ${amount} сатоші'
 receive_payment: Розрахунок
 pay: Оплата
 is: є
 trading_volume: 'Обсяг торгів: ${volume} сат'
-showusername_buying_sats: '@${username} купує ${amount}сатоші'
-showusername_selling_sats: '@${username} продає ${amount}сатоші'
+showusername_buying_sats: '@${username} купує сатоші'
+showusername_buying_sats_with_amount: '@${username} купує ${amount} сатоші'
+showusername_selling_sats: '@${username} продає сатоші'
+showusername_selling_sats_with_amount: '@${username} продає ${amount} сатоші'
 satoshis: сатоші
 by: за допомогою
 rate: Kурс

--- a/tests/bot/ordersActions.spec.ts
+++ b/tests/bot/ordersActions.spec.ts
@@ -20,40 +20,37 @@ describe('getOrderTitleMessage', () => {
 
   describe('fixed orders (amount set, price not from API)', () => {
     it('shows the sats amount when selling', () => {
-      const title = getOrderTitleMessage(
-        anonymousUser,
-        'sell',
-        100,
-        'USD',
-        false,
-        i18nCtx,
-      );
+      const title = getOrderTitleMessage(i18nCtx, {
+        user: anonymousUser,
+        type: 'sell',
+        amount: 100,
+        fiatCode: 'USD',
+        priceFromAPI: false,
+      });
 
       expect(title).to.equal('Selling 100 sats');
     });
 
     it('shows the sats amount when buying', () => {
-      const title = getOrderTitleMessage(
-        anonymousUser,
-        'buy',
-        100,
-        'USD',
-        false,
-        i18nCtx,
-      );
+      const title = getOrderTitleMessage(i18nCtx, {
+        user: anonymousUser,
+        type: 'buy',
+        amount: 100,
+        fiatCode: 'USD',
+        priceFromAPI: false,
+      });
 
       expect(title).to.equal('Buying 100 sats');
     });
 
     it('shows the username and the sats amount when the user shows their name', () => {
-      const title = getOrderTitleMessage(
-        publicUser,
-        'sell',
-        100,
-        'USD',
-        false,
-        i18nCtx,
-      );
+      const title = getOrderTitleMessage(i18nCtx, {
+        user: publicUser,
+        type: 'sell',
+        amount: 100,
+        fiatCode: 'USD',
+        priceFromAPI: false,
+      });
 
       expect(title).to.equal('@alice is selling 100 sats');
     });
@@ -61,40 +58,37 @@ describe('getOrderTitleMessage', () => {
 
   describe('market/range orders (amount is 0, price from API)', () => {
     it('omits the amount when selling', () => {
-      const title = getOrderTitleMessage(
-        anonymousUser,
-        'sell',
-        0,
-        'USD',
-        true,
-        i18nCtx,
-      );
+      const title = getOrderTitleMessage(i18nCtx, {
+        user: anonymousUser,
+        type: 'sell',
+        amount: 0,
+        fiatCode: 'USD',
+        priceFromAPI: true,
+      });
 
       expect(title).to.equal('Selling sats');
     });
 
     it('omits the amount when buying', () => {
-      const title = getOrderTitleMessage(
-        anonymousUser,
-        'buy',
-        0,
-        'USD',
-        true,
-        i18nCtx,
-      );
+      const title = getOrderTitleMessage(i18nCtx, {
+        user: anonymousUser,
+        type: 'buy',
+        amount: 0,
+        fiatCode: 'USD',
+        priceFromAPI: true,
+      });
 
       expect(title).to.equal('Buying sats');
     });
 
     it('shows the username but omits the amount when the user shows their name', () => {
-      const title = getOrderTitleMessage(
-        publicUser,
-        'buy',
-        0,
-        'USD',
-        true,
-        i18nCtx,
-      );
+      const title = getOrderTitleMessage(i18nCtx, {
+        user: publicUser,
+        type: 'buy',
+        amount: 0,
+        fiatCode: 'USD',
+        priceFromAPI: true,
+      });
 
       expect(title).to.equal('@alice is buying sats');
     });


### PR DESCRIPTION
Closes #854

## Problem

After #852 the order title keys interpolate `${amount}` with no space in the template (`'Selling ${amount}sats'`) because the separating space lives *inside* the interpolated variable as a trailing-space hack. That's invisible to translators: adding the "missing" space in the YAML produces a double space, and languages where the amount can't sit adjacent to the noun can't reorder safely.

## Changes

**Locales (all 10):** each title key is split into two explicit variants, with the space visible in the template:

```yaml
selling_sats: Selling sats                              # market/range orders
selling_sats_with_amount: 'Selling ${amount} sats'      # fixed orders
```

Same for `buying_sats` and both `showusername_*` keys. The no-amount variants restore the pre-#770 wording verbatim (e.g. French recovers "achète **des** sats", which the single-key version had to drop). The with-amount variants keep each locale's current wording, just with an explicit space — native-speaker review welcome.

**`getOrderTitleMessage`:** selects the key variant instead of building an empty-or-trailing-space string; takes an options object (`OrderTitleArguments`) instead of 6 positional params; the comment now matches the actual guard (`priceFromAPI`, not `amount === 0`).

**Spec:** `tests/bot/ordersActions.spec.ts` updated to the new signature with **identical expected strings** — the regression test from #852 passing unchanged is the proof that rendered output is preserved.

## Notes

- Rebased on main after #857 and #858 merged; the Russian keys now use the unified "сат" wording from #857 in all four variants.

## Test plan
- [x] YAML validated: all 8 keys parse and are present in the 10 locales
- [x] Full suite: 151 passing, 0 failing (includes the #852 regression test with unchanged expectations, and the #858 numberFormat tests)
- [x] `npm run lint` clean, full `npx tsc` build clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved order and trade labels across supported languages, with clearer “buy/sell sats” text.
  * Added separate message variants for labels with and without amounts.

* **Bug Fixes**
  * Fixed spacing in satoshi amounts so values now display more naturally, such as `10 sats` instead of `10sats`.
  * Fixed order titles so amount details are shown only where appropriate, avoiding extra or missing formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->