### PR TITLE
docs: require English for all repository artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # Repository Guidelines
 
+## Language
+- All repository artifacts must be written in English: source code, comments,
+  identifiers, commit messages, PR titles and descriptions, issues, and docs.
+- This applies regardless of the language used to converse with a contributor
+  or maintainer — the repository itself stays English-only.
+
 ## Project Structure & Module Organization
 - `app.ts` bootstraps the Telegram bot and Mongo connection; keep startup logic centralized there.
 - `bot/` houses commands, scenes, and middleware modules; pair new flows with text updates under `locales/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Conventions
+
+- **Language:** everything committed to this repo (code, comments, commit messages, PRs, issues, docs) must be in English. See AGENTS.md.
+
 ## Project Overview
 
 LNp2pBot is a Telegram bot that facilitates peer-to-peer Lightning Network trading. Users can create buy/sell orders for Bitcoin using Lightning Network hold invoices to ensure trustless transactions.


### PR DESCRIPTION
## What

Makes the English-only convention explicit so any contributor — human or coding agent — picks it up automatically.

- **`AGENTS.md`**: new `## Language` section stating that all repository artifacts (source code, comments, identifiers, commit messages, PR titles/descriptions, issues, docs) must be written in English, regardless of the language used to converse with a contributor.
- **`CLAUDE.md`**: a one-line pointer under a `## Conventions` heading, since Claude Code auto-loads this file.

## Why

The rule was implicit. `AGENTS.md` is the tool-agnostic guidelines file most coding agents read, so it is the canonical home; `CLAUDE.md` mirrors a short pointer to guarantee coverage for Claude Code sessions whether or not `AGENTS.md` is loaded.

Docs-only change: no runtime, build, or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5uNqd26cC88p5HVqErRDU

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5uNqd26cC88p5HVqErRDU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository language guidelines to require English for code, comments, identifiers, commit messages, pull requests, issues, and documentation.
  * Added a related note in project guidance to keep these conventions consistent across repository content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->