### PR TITLE
fix: sync buyer_invoice to the paid invoice on successful retry

### DIFF
--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -86,6 +86,12 @@ export const attemptPendingPayments = async (
       if (!!payment && !!payment.confirmed_at) {
         order.status = 'SUCCESS';
         order.routing_fee = payment.fee;
+        // Reflect the invoice that was actually paid. When a payout fails and
+        // the buyer runs /setinvoice, the retry pays a new invoice stored only
+        // on the pending payment, while order.buyer_invoice still points at the
+        // original (failed) invoice. Sync it here so the order is a faithful
+        // record of the payment (needed for reconciliation/auditing). See #864.
+        order.buyer_invoice = pending.payment_request;
         pending.paid = true;
         pending.paid_at = new Date();
         // We add a new completed trade for the buyer
@@ -96,7 +102,11 @@ export const attemptPendingPayments = async (
         if (sellerUser === null) throw Error('sellerUser was not found in DB');
         sellerUser.trades_completed++;
         sellerUser.save();
-        logger.info(`Invoice with hash: ${pending.hash} paid`);
+        // Log the real payment hash (payment.id); pending.hash stores the hold
+        // invoice hash, not the payout's, which made this line misleading (#864).
+        logger.info(
+          `Order ${order._id} - Invoice with hash: ${payment.id} paid`,
+        );
         await messages.toAdminChannelPendingPaymentSuccessMessage(
           bot,
           buyerUser,

--- a/tests/jobs/pending_payments.spec.ts
+++ b/tests/jobs/pending_payments.spec.ts
@@ -1,0 +1,166 @@
+export {};
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+/**
+ * Regression tests for issue #864: on a successful retry, the order's
+ * buyer_invoice must be synced to the invoice that was actually paid (the one
+ * stored on the pending payment), not left pointing at the original invoice.
+ */
+describe('attemptPendingPayments (issue #864)', () => {
+  const originalAttempts = process.env.PAYMENT_ATTEMPTS;
+
+  beforeEach(() => {
+    process.env.PAYMENT_ATTEMPTS = '3';
+  });
+
+  afterEach(() => {
+    process.env.PAYMENT_ATTEMPTS = originalAttempts;
+    sinon.restore();
+  });
+
+  // Builds the job with fully mocked dependencies so nothing touches Mongo/LND.
+  function load({
+    order,
+    pending,
+    payment,
+  }: {
+    order: any;
+    pending: any;
+    payment: any;
+  }) {
+    const payRequest = sinon.stub().resolves(payment);
+    const isPendingPayment = sinon.stub().resolves(false);
+    const orderUpdated = sinon.stub();
+
+    const buyerUser = {
+      _id: order.buyer_id,
+      tg_id: '1',
+      trades_completed: 0,
+      save: sinon.stub().resolves(),
+    };
+    const sellerUser = {
+      _id: order.seller_id,
+      tg_id: '2',
+      trades_completed: 0,
+      save: sinon.stub().resolves(),
+    };
+    const User = { findOne: sinon.stub() };
+    User.findOne.withArgs({ _id: order.buyer_id }).resolves(buyerUser);
+    User.findOne.withArgs({ _id: order.seller_id }).resolves(sellerUser);
+
+    const models = {
+      PendingPayment: { find: sinon.stub().resolves([pending]) },
+      Order: { findOne: sinon.stub().resolves(order) },
+      User,
+      Community: {},
+    };
+
+    const messages = {
+      __esModule: true,
+      toAdminChannelPendingPaymentSuccessMessage: sinon.stub().resolves(),
+      toBuyerPendingPaymentSuccessMessage: sinon.stub().resolves(),
+      rateUserMessage: sinon.stub().resolves(),
+      expiredInvoiceOnPendingMessage: sinon.stub().resolves(),
+      toBuyerPendingPaymentFailedMessage: sinon.stub().resolves(),
+      toAdminChannelPendingPaymentFailedMessage: sinon.stub().resolves(),
+    };
+
+    const { attemptPendingPayments } = proxyquire(
+      '../../jobs/pending_payments',
+      {
+        '../models': models,
+        '../bot/messages': messages,
+        '../logger': {
+          logger: {
+            info: sinon.stub(),
+            error: sinon.stub(),
+            warning: sinon.stub(),
+          },
+        },
+        '../ln': { payRequest, isPendingPayment },
+        '../util': {
+          getUserI18nContext: sinon.stub().resolves({ t: (k: string) => k }),
+        },
+        '../bot/modules/events/orders': { orderUpdated },
+      },
+    );
+
+    return { attemptPendingPayments, payRequest, orderUpdated, buyerUser };
+  }
+
+  it('syncs buyer_invoice to the paid invoice when a retry succeeds', async () => {
+    const order = {
+      _id: 'order1',
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      amount: 1000,
+      status: 'PAID_HOLD_INVOICE',
+      hash: 'hold-hash',
+      buyer_invoice: 'lnbc-original-failed',
+      routing_fee: 0,
+      save: sinon.stub().resolves(),
+    };
+    const pending = {
+      _id: 'pp1',
+      order_id: 'order1',
+      amount: 1000,
+      payment_request: 'lnbc-new-retry',
+      hash: 'hold-hash',
+      attempts: 0,
+      paid: false,
+      is_invoice_expired: false,
+      save: sinon.stub().resolves(),
+    };
+    const payment = {
+      confirmed_at: '2026-01-01T00:00:00Z',
+      id: 'real-payment-hash',
+      fee: 5,
+      secret: 'preimage',
+    };
+
+    const { attemptPendingPayments } = load({ order, pending, payment });
+    await attemptPendingPayments({} as any);
+
+    expect(order.status).to.equal('SUCCESS');
+    expect(order.buyer_invoice).to.equal('lnbc-new-retry');
+    expect(order.routing_fee).to.equal(5);
+    expect(pending.paid).to.equal(true);
+    expect(order.save.called).to.equal(true);
+  });
+
+  it('leaves buyer_invoice untouched when the payment does not confirm', async () => {
+    const order = {
+      _id: 'order2',
+      buyer_id: 'buyer2',
+      seller_id: 'seller2',
+      amount: 1000,
+      status: 'PAID_HOLD_INVOICE',
+      hash: 'hold-hash',
+      buyer_invoice: 'lnbc-original',
+      routing_fee: 0,
+      save: sinon.stub().resolves(),
+    };
+    const pending = {
+      _id: 'pp2',
+      order_id: 'order2',
+      amount: 1000,
+      payment_request: 'lnbc-new-retry',
+      hash: 'hold-hash',
+      attempts: 0,
+      paid: false,
+      is_invoice_expired: false,
+      save: sinon.stub().resolves(),
+    };
+    const payment = { error: 'ROUTING_FAILED', message: 'no route' };
+
+    const { attemptPendingPayments } = load({ order, pending, payment });
+    await attemptPendingPayments({} as any);
+
+    expect(order.status).to.equal('PAID_HOLD_INVOICE');
+    expect(order.buyer_invoice).to.equal('lnbc-original');
+    expect(pending.paid).to.equal(false);
+  });
+});


### PR DESCRIPTION
Closes #864.

## Problem

When a payout to a buyer fails and the buyer runs `/setinvoice`, the retry pays a **new** invoice that is stored only on the `PendingPayment` (`payment_request`), while `order.buyer_invoice` keeps pointing at the original, failed invoice. So any order that ended up `SUCCESS` via a retry recorded an invoice that was **never paid** — the real payment lived only in `pendingpayments.payment_request`.

This breaks reconciliation and auditing against the node (verifying the `SUCCESS` by the payment hash of `order.buyer_invoice` yields a false "payment not found"), and misleads anyone inspecting the order.

## Fix

In the `payment.confirmed_at` block of `attemptPendingPayments` (`jobs/pending_payments.ts`), set:

```ts
order.buyer_invoice = pending.payment_request;
```

so the order faithfully records the invoice that was actually paid.

Doing it **on confirmation** (and not in `/setinvoice`) is deliberate: it preserves the double-payment defense at `jobs/pending_payments.ts:41` (`isPendingOldPayment`), which needs the old invoice around to detect a previous HTLC still in flight. Touching the field only on the success path does not interfere with that logic.

Also logs the real payment hash (`payment.id`) instead of `pending.hash` — the latter stores the **hold** invoice hash, which made the `Invoice with hash ... paid` log line misleading. This matches the existing log style in `payToBuyer`.

## Scope note

This fixes the data going forward. Orders already completed via a retry keep the old inconsistency, so external DB consumers (e.g. the stats dashboard) still need their `pendingpayments` fallback for the historical backlog. The two are complementary.

## Tests

Adds `tests/jobs/pending_payments.spec.ts` with two cases:
- successful retry → `order.buyer_invoice` is synced to the paid invoice, status `SUCCESS`, routing fee recorded;
- non-confirming payment → `buyer_invoice` is left untouched and the pending payment is not marked paid.

Both pass; `npx tsc` compiles cleanly and Prettier reports no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5uNqd26cC88p5HVqErRDU

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5uNqd26cC88p5HVqErRDU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When a pending payment retry succeeds, the order now records the actual paid invoice instead of the original one.
  * Success logs now show the real payment hash, making payment records easier to trace.
  * Added regression coverage to ensure successful retries update payment status and fees correctly, while failed retries leave the order unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->