### PR TITLE
feat: persist buyer payout payment hash and preimage on the order

### DIFF
--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -86,6 +86,11 @@ export const attemptPendingPayments = async (
       if (!!payment && !!payment.confirmed_at) {
         order.status = 'SUCCESS';
         order.routing_fee = payment.fee;
+        // Persist proof of the buyer payout: the payment hash and its preimage.
+        // These live only on the node otherwise, so recording them makes the
+        // order a self-contained, verifiable record of the payment (issue #869).
+        order.payout_hash = payment.id;
+        order.payout_preimage = payment.secret;
         pending.paid = true;
         pending.paid_at = new Date();
         // We add a new completed trade for the buyer

--- a/ln/pay_request.ts
+++ b/ln/pay_request.ts
@@ -150,6 +150,11 @@ const payToBuyer = async (bot: HasTelegram, order: IOrder) => {
       logger.info(`Order ${order._id} - Invoice with hash: ${payment.id} paid`);
       order.status = 'SUCCESS';
       order.routing_fee = payment.fee;
+      // Persist proof of the buyer payout: the payment hash and its preimage.
+      // These live only on the node otherwise, so recording them makes the
+      // order a self-contained, verifiable record of the payment (issue #869).
+      order.payout_hash = payment.id;
+      order.payout_preimage = payment.secret;
 
       await order.save();
       OrderEvents.orderUpdated(order);

--- a/models/order.ts
+++ b/models/order.ts
@@ -12,6 +12,8 @@ export interface IOrder extends Document<string> {
   routing_fee: number;
   hash: string | null;
   secret: string | null;
+  payout_hash: string | null;
+  payout_preimage: string | null;
   creator_id: string;
   seller_id: string | null;
   buyer_id: string | null;
@@ -84,6 +86,8 @@ const orderSchema = new Schema<IOrder, mongoose.Model<IOrder>>({
       partialFilterExpression: { secret: { $type: 'string' } },
     },
   }, // hold invoice secret
+  payout_hash: { type: String }, // payment hash of the outgoing payment to the buyer
+  payout_preimage: { type: String }, // preimage (proof of payment) of the buyer payout
   creator_id: { type: String },
   seller_id: { type: String },
   buyer_id: { type: String },

--- a/tests/ln/payout_proof.spec.ts
+++ b/tests/ln/payout_proof.spec.ts
@@ -1,0 +1,98 @@
+export {};
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+/**
+ * Regression test for issue #869: a successful buyer payout must persist the
+ * payment hash and preimage (proof of payment) on the order.
+ */
+describe('payToBuyer payout proof (issue #869)', () => {
+  const originalMaxRoutingFee = process.env.MAX_ROUTING_FEE;
+
+  beforeEach(() => {
+    process.env.MAX_ROUTING_FEE = '0.001';
+  });
+
+  afterEach(() => {
+    process.env.MAX_ROUTING_FEE = originalMaxRoutingFee;
+    sinon.restore();
+  });
+
+  it('stores payout_hash and payout_preimage on success', async () => {
+    const payment = {
+      confirmed_at: '2026-01-01T00:00:00Z',
+      id: 'payment-hash',
+      secret: 'preimage',
+      fee: 3,
+    };
+
+    const buyerUser = { _id: 'buyer1', tg_id: '1' };
+    const sellerUser = { _id: 'seller1', tg_id: '2' };
+    const User = { findOne: sinon.stub() };
+    User.findOne.withArgs({ _id: 'buyer1' }).resolves(buyerUser);
+    User.findOne.withArgs({ _id: 'seller1' }).resolves(sellerUser);
+
+    const { payToBuyer } = proxyquire('../../ln/pay_request', {
+      lightning: {
+        payViaPaymentRequest: sinon.stub().resolves(payment),
+        getPayment: sinon.stub().resolves({ is_pending: false }),
+        deleteForwardingReputations: sinon.stub().resolves(),
+      },
+      './connect': { default: {} },
+      '../models': { User, PendingPayment: function () {} },
+      '../util': {
+        handleReputationItems: sinon.stub().resolves(),
+        getUserI18nContext: sinon.stub().resolves({ t: (k: string) => k }),
+      },
+      '../bot/messages': {
+        __esModule: true,
+        buyerReceivedSatsMessage: sinon.stub().resolves(),
+        rateUserMessage: sinon.stub().resolves(),
+        invoicePaymentFailedMessage: sinon.stub().resolves(),
+        expiredInvoiceOnPendingMessage: sinon.stub().resolves(),
+      },
+      '../logger': {
+        logger: {
+          info: sinon.stub(),
+          error: sinon.stub(),
+          warning: sinon.stub(),
+        },
+        logTimeout: sinon.stub(),
+        logOperationDuration: sinon.stub(),
+      },
+      '../bot/modules/events/orders': {
+        __esModule: true,
+        orderUpdated: sinon.stub(),
+      },
+      invoices: {
+        parsePaymentRequest: sinon
+          .stub()
+          .returns({ id: 'payment-hash', is_expired: false }),
+      },
+    });
+
+    const order = {
+      _id: 'order1',
+      amount: 1000,
+      description: '',
+      buyer_invoice: 'lnbc-buyer',
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      status: 'PAID_HOLD_INVOICE',
+      routing_fee: 0,
+      payout_hash: null,
+      payout_preimage: null,
+      save: sinon.stub().resolves(),
+    };
+
+    await payToBuyer({} as any, order as any);
+
+    expect(order.status).to.equal('SUCCESS');
+    expect(order.payout_hash).to.equal('payment-hash');
+    expect(order.payout_preimage).to.equal('preimage');
+    expect(order.routing_fee).to.equal(3);
+    expect(order.save.called).to.equal(true);
+  });
+});


### PR DESCRIPTION
Closes #869.

## What

An order recorded the **hold invoice** hash/secret (`order.hash`, `order.secret`) but nothing about the **outgoing payment to the buyer**. The payout's payment hash and its preimage (proof of payment) were available on the payment result (`payment.id`, `payment.secret`) but discarded — only the routing fee was kept.

- Add `payout_hash` and `payout_preimage` to the Order model (`models/order.ts`).
- Set them from `payment.id` / `payment.secret` in both buyer-payout success paths: `payToBuyer` (`ln/pay_request.ts`) and `attemptPendingPayments` (`jobs/pending_payments.ts`).

## Why

- **Proof of payment**: the preimage is cryptographic proof the buyer was paid; today it lives only on the node.
- **Robust reconciliation/auditing**: consumers can read the outbound hash directly instead of re-deriving it from `buyer_invoice` (which is fragile with retried invoices — see #864).
- **Traceability**: an operator can see exactly which payment settled an order.

Scoped to buyer payouts (which have an order). Community earnings withdrawals have no order and already store their payout hash on the pending payment.

## Scope note

Records the values going forward; orders completed before this change keep empty `payout_hash`/`payout_preimage`, so consumers should keep deriving the hash from `buyer_invoice` for the historical backlog. The two are complementary.

## Tests

Adds `tests/ln/payout_proof.spec.ts` asserting a successful `payToBuyer` sets `payout_hash`, `payout_preimage` and `routing_fee`. `npx tsc` compiles cleanly; Prettier and ESLint report no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5uNqd26cC88p5HVqErRDU

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5uNqd26cC88p5HVqErRDU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Successful payouts now save additional proof details on the order, making completed payment records easier to verify later.
  * Order records now keep both the payout hash and payout preimage alongside the existing success status and routing fee.
* **Tests**
  * Added regression coverage to confirm payout proof is stored correctly after a successful buyer payout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->