### PR TITLE
feat(order): persist buyer payout hash and preimage

### DIFF
--- a/ln/pay_request.ts
+++ b/ln/pay_request.ts
@@ -161,6 +161,8 @@ const payToBuyer = async (bot: HasTelegram, order: IOrder) => {
       logger.info(`Order ${order._id} - Invoice with hash: ${payment.id} paid`);
       order.status = 'SUCCESS';
       order.routing_fee = payment.fee;
+      order.payout_hash = payment.id;
+      order.payout_preimage = payment.secret;
 
       await order.save();
       OrderEvents.orderUpdated(order);

--- a/models/order.ts
+++ b/models/order.ts
@@ -10,6 +10,8 @@ export interface IOrder extends Document<string> {
   bot_fee: number;
   community_fee: number;
   routing_fee: number;
+  payout_hash?: string | null;
+  payout_preimage?: string | null;
   hash: string | null;
   secret: string | null;
   creator_id: string;
@@ -70,6 +72,8 @@ const orderSchema = new Schema<IOrder, mongoose.Model<IOrder>>({
   bot_fee: { type: Number, min: 0 }, // bot MAX_FEE at the moment of order creation
   community_fee: { type: Number, min: 0 }, // community FEE_PERCENT at the moment of order creation
   routing_fee: { type: Number, min: 0, default: 0 },
+  payout_hash: { type: String }, // payment hash of the buyer payout (proof of payment / reconciliation)
+  payout_preimage: { type: String }, // preimage of the buyer payout (cryptographic proof it settled)
   hash: {
     type: String,
     index: {

--- a/tests/bot/pending-payments.spec.ts
+++ b/tests/bot/pending-payments.spec.ts
@@ -35,6 +35,8 @@ function makeFakeOrder(overrides = {}) {
     fiat_code: 'ARS',
     status: 'PAID_HOLD_INVOICE',
     routing_fee: 0,
+    payout_hash: null,
+    payout_preimage: null,
     paid_hold_buyer_invoice_updated: false,
     save: sinon.stub().resolves(),
     ...overrides,
@@ -198,6 +200,14 @@ describe('attemptPendingPayments healing branches', () => {
 
       expect(order.status).to.equal('SUCCESS', 'order must be marked SUCCESS');
       expect(order.routing_fee).to.equal(fakePayment.fee);
+      expect(order.payout_hash).to.equal(
+        fakePayment.id,
+        'payout hash must be persisted for reconciliation',
+      );
+      expect(order.payout_preimage).to.equal(
+        fakePayment.secret,
+        'payout preimage (proof of payment) must be persisted',
+      );
       expect(pending.paid).to.equal(true);
       expect(buyer.trades_completed).to.equal(
         6,

--- a/util/completeOrder.ts
+++ b/util/completeOrder.ts
@@ -30,12 +30,21 @@ export const completeOrderAsSuccess = async (
   // If this coroutine come first and successfully updated the order status then continue the routine
   const won = await Order.findOneAndUpdate(
     { _id: order._id, status: { $ne: 'SUCCESS' } },
-    { $set: { status: 'SUCCESS', routing_fee: payment.fee } },
+    {
+      $set: {
+        status: 'SUCCESS',
+        routing_fee: payment.fee,
+        payout_hash: payment.id,
+        payout_preimage: payment.secret,
+      },
+    },
   );
   if (won === null) return false;
   // Keep the in-memory document consistent for any later save by the caller.
   order.status = 'SUCCESS';
   order.routing_fee = payment.fee;
+  order.payout_hash = payment.id;
+  order.payout_preimage = payment.secret;
 
   if (pending) {
     pending.paid = true;


### PR DESCRIPTION
Closes #869.

## Summary

An order records the **hold invoice** hash/secret (`order.hash`, `order.secret`) but nothing about the **outgoing payment to the buyer**. The payout's payment hash (`payment.id`) and preimage (`payment.secret`) are available on every successful payment result, but they were discarded — only `order.routing_fee` was kept.

This persists them as two new optional fields on the order: `payout_hash` and `payout_preimage`.

## Why

- **Proof of payment.** The preimage is cryptographic proof the buyer was actually paid. Today that proof lives only on the node; if the node history is lost or migrated, the DB cannot prove the payout happened.
- **Robust reconciliation / auditing.** Accounting over the bot's data (e.g. the external stats dashboard) currently has to re-derive the outbound hash by parsing `order.buyer_invoice` — which is also left stale after a retried `/setinvoice` (see #864). Storing `payout_hash` makes that a direct field lookup and removes a class of edge cases. This matters in practice: it is exactly what makes it easy to tell a real payout anomaly apart from a reconciliation artifact when auditing against the node.
- **Traceability.** An operator inspecting an order can see exactly which payment settled it.

## Changes

- `models/order.ts` — add `payout_hash?: string | null` and `payout_preimage?: string | null` (plain `String`, no index).
- `util/completeOrder.ts` — set both in `completeOrderAsSuccess` (the single buyer-payout success choke point, covering the pending-payment retry and `healConfirmedOrder` paths), inside the atomic `$set` and the in-memory copy.
- `ln/pay_request.ts` — set both in the first-attempt success branch of `payToBuyer`.
- `tests/bot/pending-payments.spec.ts` — assert both are persisted on the success routine.

Scoped to buyer payouts (which have an order). Community earnings withdrawals have no order; their payout hash is already stored on the pending payment.

## Note

This records the values going forward. Orders completed before this change will have empty `payout_hash`/`payout_preimage`, so consumers should keep deriving the hash from `buyer_invoice` for the historical backlog. The two are complementary.

## Verification

- `tsc -p tsconfig.test.json` — passes.
- `eslint` + `prettier --check` on the changed files — clean.
- Runtime check of the compiled `completeOrderAsSuccess` confirms `payout_hash` / `payout_preimage` / `routing_fee` are set on success. (The full mocha suite could not run in this environment because the native `canvas` dependency fails to build without cairo/pango — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7M5Q5My6Sgvvo8qS6zZCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7M5Q5My6Sgvvo8qS6zZCE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lightning payout hash and preimage details are now saved when an order payment succeeds.
  - Order records retain payout information for completed payments.

- **Bug Fixes**
  - Improved consistency between completed order records and their associated Lightning payments.
  - Confirmed payments now preserve payout details during payment recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->