### PR TITLE
Fix invoice tracking for retried payments (issue #864)

### DIFF
--- a/bot/scenes.ts
+++ b/bot/scenes.ts
@@ -184,7 +184,15 @@ const addInvoicePHIWizard = new Scenes.WizardScene(
         // makes this a no-op if the pending-payments job already closed it, so
         // the buyer is not notified twice); if LND returned no payload the order
         // is flagged ERROR and the admin channel is notified.
-        const healed = await healConfirmedOrder(bot, order, originalStatus);
+        // The confirmed payment is the original buyer_invoice (the one just
+        // re-submitted), so record it as the paid invoice.
+        const healed = await healConfirmedOrder(
+          bot,
+          order,
+          originalStatus,
+          undefined,
+          order.buyer_invoice,
+        );
         if (!healed) {
           const i18nCtx = await getUserI18nContext(buyer);
           await messages.genericErrorMessage(bot, buyer, i18nCtx);

--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -80,7 +80,14 @@ export const attemptPendingPayments = async (
           logger.info(
             `Order ${order._id}: original buyer invoice already confirmed, running success routine`,
           );
-          await healConfirmedOrder(bot, order, originalStatus, pending);
+          // The original buyer_invoice is the one that was paid here.
+          await healConfirmedOrder(
+            bot,
+            order,
+            originalStatus,
+            pending,
+            order.buyer_invoice,
+          );
           continue;
         }
         if (originalStatus.is_pending) {
@@ -137,7 +144,14 @@ export const attemptPendingPayments = async (
           await prev.save();
           pending.is_invoice_expired = true; // prevents retrying on this PendingPayment
           await pending.save();
-          await healConfirmedOrder(bot, order, prevStatus, prev);
+          // prev.payment_request is the invoice that was actually paid.
+          await healConfirmedOrder(
+            bot,
+            order,
+            prevStatus,
+            prev,
+            prev.payment_request,
+          );
           shouldSkip = true;
           break;
         } else if (prevStatus.is_pending) {
@@ -160,7 +174,14 @@ export const attemptPendingPayments = async (
         logger.info(
           `Invoice with hash: ${pending.hash} already paid, running success routine`,
         );
-        await healConfirmedOrder(bot, order, currentStatus, pending);
+        // pending.payment_request is the invoice that was actually paid.
+        await healConfirmedOrder(
+          bot,
+          order,
+          currentStatus,
+          pending,
+          pending.payment_request,
+        );
         continue;
       }
 
@@ -226,9 +247,16 @@ export const attemptPendingPayments = async (
       }
 
       if (!!payment && !!payment.confirmed_at) {
-        logger.info(`Invoice with hash: ${pending.hash} paid`);
+        // Log the real payment hash (payment.id); pending.hash stores the hold
+        // invoice hash, not the payout's, which made this line misleading (#864).
+        logger.info(
+          `Order ${order._id} - Invoice with hash: ${payment.id} paid`,
+        );
         const sellerUser = await User.findOne({ _id: order.seller_id });
         if (sellerUser === null) throw Error('sellerUser was not found in DB');
+        // Record the invoice actually paid (pending.payment_request) in
+        // order.buyer_invoice_paid, without overwriting the original
+        // order.buyer_invoice, so reconciliation/auditing can rely on it. See #864.
         await completeOrderAsSuccess(
           bot,
           order,
@@ -237,6 +265,7 @@ export const attemptPendingPayments = async (
           sellerUser,
           i18nCtx,
           pending,
+          pending.payment_request,
         );
       } else {
         // Enhanced error handling for different payment failure types

--- a/ln/pay_request.ts
+++ b/ln/pay_request.ts
@@ -163,6 +163,7 @@ const payToBuyer = async (bot: HasTelegram, order: IOrder) => {
       order.routing_fee = payment.fee;
       order.payout_hash = payment.id;
       order.payout_preimage = payment.secret;
+      order.buyer_invoice_paid = order.buyer_invoice;
 
       await order.save();
       OrderEvents.orderUpdated(order);

--- a/models/order.ts
+++ b/models/order.ts
@@ -18,6 +18,7 @@ export interface IOrder extends Document<string> {
   seller_id: string | null;
   buyer_id: string | null;
   buyer_invoice: string;
+  buyer_invoice_paid?: string;
   buyer_dispute_token: string;
   seller_dispute_token: string;
   buyer_dispute: boolean;
@@ -91,7 +92,12 @@ const orderSchema = new Schema<IOrder, mongoose.Model<IOrder>>({
   creator_id: { type: String },
   seller_id: { type: String },
   buyer_id: { type: String },
-  buyer_invoice: { type: String },
+  buyer_invoice: { type: String }, // invoice originally provided by the buyer
+  // Invoice that was actually paid to the buyer. When a payout fails and the
+  // buyer runs /setinvoice, the retry pays a new invoice; we persist it here so
+  // buyer_invoice (the original) is never lost and reconciliation/auditing can
+  // rely on the real paid invoice. See #864.
+  buyer_invoice_paid: { type: String },
   buyer_dispute_token: { type: String },
   seller_dispute_token: { type: String },
   buyer_dispute: { type: Boolean, default: false },

--- a/tests/jobs/pending_payments.spec.ts
+++ b/tests/jobs/pending_payments.spec.ts
@@ -1,0 +1,238 @@
+export {};
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+/**
+ * Regression tests for issue #864: on a successful retry, the order must record
+ * the invoice that was actually paid (the one stored on the pending payment) in
+ * a dedicated field (buyer_invoice_paid), while the original buyer_invoice is
+ * preserved so no data is lost for debugging/reconciliation.
+ */
+describe('attemptPendingPayments (issue #864)', () => {
+  const originalAttempts = process.env.PAYMENT_ATTEMPTS;
+
+  beforeEach(() => {
+    process.env.PAYMENT_ATTEMPTS = '3';
+  });
+
+  afterEach(() => {
+    process.env.PAYMENT_ATTEMPTS = originalAttempts;
+    sinon.restore();
+  });
+
+  // A payment status that is neither confirmed nor pending, so the job falls
+  // through the double-pay guards and actually attempts the retry payment.
+  const notPaidStatus = {
+    is_confirmed: false,
+    is_pending: false,
+    is_error: false,
+  };
+
+  // Builds the job with fully mocked dependencies so nothing touches Mongo/LND.
+  function load({
+    order,
+    pending,
+    payment,
+  }: {
+    order: any;
+    pending: any;
+    payment: any;
+  }) {
+    const payRequest = sinon.stub().resolves(payment);
+    const getPaymentStatus = sinon.stub().resolves(notPaidStatus);
+    const orderUpdated = sinon.stub();
+
+    const buyerUser = {
+      _id: order.buyer_id,
+      tg_id: '1',
+      trades_completed: 0,
+      save: sinon.stub().resolves(),
+    };
+    const sellerUser = {
+      _id: order.seller_id,
+      tg_id: '2',
+      trades_completed: 0,
+      save: sinon.stub().resolves(),
+    };
+    const User = { findOne: sinon.stub() };
+    User.findOne.withArgs({ _id: order.buyer_id }).resolves(buyerUser);
+    User.findOne.withArgs({ _id: order.seller_id }).resolves(sellerUser);
+
+    // find is called twice: the main pending-payments query and, later, the
+    // previousPendingPayments lookup. Return the pending on the first call and
+    // an empty list afterwards.
+    const find = sinon.stub();
+    find.onFirstCall().resolves([pending]);
+    find.resolves([]);
+
+    const models = {
+      PendingPayment: {
+        find,
+        countDocuments: sinon.stub().resolves(0),
+      },
+      Order: { findOne: sinon.stub().resolves(order) },
+      User,
+      Community: {},
+    };
+
+    const messages = {
+      __esModule: true,
+      toAdminChannelPendingPaymentSuccessMessage: sinon.stub().resolves(),
+      toBuyerPendingPaymentSuccessMessage: sinon.stub().resolves(),
+      rateUserMessage: sinon.stub().resolves(),
+      expiredInvoiceOnPendingMessage: sinon.stub().resolves(),
+      toBuyerPendingPaymentFailedMessage: sinon.stub().resolves(),
+      toAdminChannelPendingPaymentFailedMessage: sinon.stub().resolves(),
+      toAdminChannelOrderErrorMessage: sinon.stub().resolves(),
+    };
+
+    // Stub the shared success routine so we can assert the job's behaviour in
+    // isolation. It emulates the real side effects we care about here.
+    const completeOrderAsSuccess = sinon
+      .stub()
+      .callsFake(
+        async (
+          _bot: any,
+          ord: any,
+          pay: any,
+          _b: any,
+          _s: any,
+          _i: any,
+          pend: any,
+          paidInvoice?: string,
+        ) => {
+          ord.status = 'SUCCESS';
+          ord.routing_fee = pay.fee;
+          if (paidInvoice) ord.buyer_invoice_paid = paidInvoice;
+          if (pend) {
+            pend.paid = true;
+            pend.paid_at = new Date();
+          }
+          return true;
+        },
+      );
+    const healConfirmedOrder = sinon.stub().resolves(true);
+
+    const { attemptPendingPayments } = proxyquire(
+      '../../jobs/pending_payments',
+      {
+        '../models': models,
+        '../bot/messages': messages,
+        '../logger': {
+          logger: {
+            info: sinon.stub(),
+            error: sinon.stub(),
+            warning: sinon.stub(),
+            warn: sinon.stub(),
+          },
+        },
+        '../ln': { payRequest, getPaymentStatus },
+        '../util': {
+          getUserI18nContext: sinon.stub().resolves({ t: (k: string) => k }),
+        },
+        '../bot/modules/events/orders': { orderUpdated },
+        '../util/completeOrder': { completeOrderAsSuccess, healConfirmedOrder },
+      },
+    );
+
+    return {
+      attemptPendingPayments,
+      payRequest,
+      orderUpdated,
+      buyerUser,
+      completeOrderAsSuccess,
+    };
+  }
+
+  it('records the paid invoice in buyer_invoice_paid and keeps the original buyer_invoice when a retry succeeds', async () => {
+    const order: any = {
+      _id: 'order1',
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      amount: 1000,
+      status: 'PAID_HOLD_INVOICE',
+      hash: 'hold-hash',
+      buyer_invoice: 'lnbc-original-failed',
+      routing_fee: 0,
+      save: sinon.stub().resolves(),
+    };
+    const pending = {
+      _id: 'pp1',
+      order_id: 'order1',
+      amount: 1000,
+      payment_request: 'lnbc-new-retry',
+      hash: 'hold-hash',
+      attempts: 0,
+      paid: false,
+      is_invoice_expired: false,
+      save: sinon.stub().resolves(),
+    };
+    const payment = {
+      confirmed_at: '2026-01-01T00:00:00Z',
+      id: 'real-payment-hash',
+      fee: 5,
+      secret: 'preimage',
+    };
+
+    const { attemptPendingPayments, completeOrderAsSuccess } = load({
+      order,
+      pending,
+      payment,
+    });
+    await attemptPendingPayments({} as any);
+
+    expect(completeOrderAsSuccess.called).to.equal(true);
+    // The job forwards the actually-paid invoice (pending.payment_request) as
+    // the paidInvoice argument (8th) of completeOrderAsSuccess.
+    expect(completeOrderAsSuccess.firstCall.args[7]).to.equal('lnbc-new-retry');
+    expect(order.status).to.equal('SUCCESS');
+    // The paid invoice is recorded in the dedicated field...
+    expect(order.buyer_invoice_paid).to.equal('lnbc-new-retry');
+    // ...and the original invoice is preserved (not overwritten).
+    expect(order.buyer_invoice).to.equal('lnbc-original-failed');
+    expect(order.routing_fee).to.equal(5);
+    expect(pending.paid).to.equal(true);
+    expect(order.save.called).to.equal(true);
+  });
+
+  it('leaves buyer_invoice and buyer_invoice_paid untouched when the payment does not confirm', async () => {
+    const order: any = {
+      _id: 'order2',
+      buyer_id: 'buyer2',
+      seller_id: 'seller2',
+      amount: 1000,
+      status: 'PAID_HOLD_INVOICE',
+      hash: 'hold-hash',
+      buyer_invoice: 'lnbc-original',
+      routing_fee: 0,
+      save: sinon.stub().resolves(),
+    };
+    const pending = {
+      _id: 'pp2',
+      order_id: 'order2',
+      amount: 1000,
+      payment_request: 'lnbc-new-retry',
+      hash: 'hold-hash',
+      attempts: 0,
+      paid: false,
+      is_invoice_expired: false,
+      save: sinon.stub().resolves(),
+    };
+    const payment = { error: 'ROUTING_FAILED', message: 'no route' };
+
+    const { attemptPendingPayments, completeOrderAsSuccess } = load({
+      order,
+      pending,
+      payment,
+    });
+    await attemptPendingPayments({} as any);
+
+    expect(completeOrderAsSuccess.called).to.equal(false);
+    expect(order.status).to.equal('PAID_HOLD_INVOICE');
+    expect(order.buyer_invoice).to.equal('lnbc-original');
+    expect(order.buyer_invoice_paid).to.equal(undefined);
+    expect(pending.paid).to.equal(false);
+  });
+});

--- a/tests/util/completeOrder.spec.ts
+++ b/tests/util/completeOrder.spec.ts
@@ -1,0 +1,129 @@
+export {};
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+/**
+ * Unit tests for issue #864: completeOrderAsSuccess must record the invoice that
+ * was actually paid in order.buyer_invoice_paid (written atomically with the
+ * SUCCESS flip) without ever overwriting the original order.buyer_invoice.
+ */
+describe('completeOrderAsSuccess (issue #864)', () => {
+  afterEach(() => sinon.restore());
+
+  function load({ won }: { won: any }) {
+    const findOneAndUpdate = sinon.stub().resolves(won);
+    const messages = {
+      __esModule: true,
+      toAdminChannelPendingPaymentSuccessMessage: sinon.stub().resolves(),
+      toBuyerPendingPaymentSuccessMessage: sinon.stub().resolves(),
+      rateUserMessage: sinon.stub().resolves(),
+      toAdminChannelOrderErrorMessage: sinon.stub().resolves(),
+    };
+    const mod = proxyquire('../../util/completeOrder', {
+      '../models': {
+        Order: { findOneAndUpdate },
+        User: { findOne: sinon.stub() },
+      },
+      '../bot/messages': messages,
+      '../logger': { logger: { info: sinon.stub(), error: sinon.stub() } },
+      '../util': {
+        getUserI18nContext: sinon.stub().resolves({ t: (k: string) => k }),
+      },
+    });
+    return {
+      completeOrderAsSuccess: mod.completeOrderAsSuccess,
+      findOneAndUpdate,
+    };
+  }
+
+  const makeArgs = () => {
+    const order: any = {
+      _id: 'o1',
+      buyer_id: 'b1',
+      seller_id: 's1',
+      buyer_invoice: 'lnbc-original',
+      status: 'PAID_HOLD_INVOICE',
+    };
+    const buyerUser: any = {
+      trades_completed: 0,
+      save: sinon.stub().resolves(),
+    };
+    const sellerUser: any = {
+      trades_completed: 0,
+      save: sinon.stub().resolves(),
+    };
+    const payment: any = { fee: 7, id: 'real-hash', secret: 'preimage' };
+    const i18nCtx: any = { t: (k: string) => k };
+    return { order, buyerUser, sellerUser, payment, i18nCtx };
+  };
+
+  it('records buyer_invoice_paid atomically and in memory, keeping buyer_invoice, when paidInvoice is provided', async () => {
+    const { order, buyerUser, sellerUser, payment, i18nCtx } = makeArgs();
+    const { completeOrderAsSuccess, findOneAndUpdate } = load({
+      won: { _id: 'o1' },
+    });
+
+    const result = await completeOrderAsSuccess(
+      {} as any,
+      order,
+      payment,
+      buyerUser,
+      sellerUser,
+      i18nCtx,
+      undefined,
+      'lnbc-new-retry',
+    );
+
+    expect(result).to.equal(true);
+    // Written in the same atomic $set as the SUCCESS flip.
+    const setArg = findOneAndUpdate.firstCall.args[1].$set;
+    expect(setArg.status).to.equal('SUCCESS');
+    expect(setArg.routing_fee).to.equal(7);
+    expect(setArg.buyer_invoice_paid).to.equal('lnbc-new-retry');
+    // ...and mirrored in memory, with the original preserved.
+    expect(order.buyer_invoice_paid).to.equal('lnbc-new-retry');
+    expect(order.buyer_invoice).to.equal('lnbc-original');
+  });
+
+  it('does not set buyer_invoice_paid when no paidInvoice is provided', async () => {
+    const { order, buyerUser, sellerUser, payment, i18nCtx } = makeArgs();
+    const { completeOrderAsSuccess, findOneAndUpdate } = load({
+      won: { _id: 'o1' },
+    });
+
+    await completeOrderAsSuccess(
+      {} as any,
+      order,
+      payment,
+      buyerUser,
+      sellerUser,
+      i18nCtx,
+    );
+
+    const setArg = findOneAndUpdate.firstCall.args[1].$set;
+    expect('buyer_invoice_paid' in setArg).to.equal(false);
+    expect(order.buyer_invoice_paid).to.equal(undefined);
+  });
+
+  it('returns false and leaves buyer_invoice_paid untouched when it loses the CAS race', async () => {
+    const { order, buyerUser, sellerUser, payment, i18nCtx } = makeArgs();
+    const { completeOrderAsSuccess } = load({ won: null });
+
+    const result = await completeOrderAsSuccess(
+      {} as any,
+      order,
+      payment,
+      buyerUser,
+      sellerUser,
+      i18nCtx,
+      undefined,
+      'lnbc-new-retry',
+    );
+
+    expect(result).to.equal(false);
+    expect(order.buyer_invoice_paid).to.equal(undefined);
+    expect(order.status).to.equal('PAID_HOLD_INVOICE');
+  });
+});

--- a/util/completeOrder.ts
+++ b/util/completeOrder.ts
@@ -26,18 +26,24 @@ export const completeOrderAsSuccess = async (
   sellerUser: UserDocument,
   i18nCtx: I18nContext,
   pending?: IPendingPayment,
+  // The invoice that was actually paid. When a payout is retried after the buyer
+  // runs /setinvoice, the buyer is paid on a new invoice, so order.buyer_invoice
+  // (the original) no longer reflects the real payment. Callers pass the paid
+  // invoice here so it is recorded in order.buyer_invoice_paid without losing the
+  // original invoice. See #864.
+  paidInvoice?: string,
 ): Promise<boolean> => {
+  const update: Record<string, unknown> = {
+    status: 'SUCCESS',
+    routing_fee: payment.fee,
+    payout_hash: payment.id,
+    payout_preimage: payment.secret,
+  };
+  if (paidInvoice) update.buyer_invoice_paid = paidInvoice;
   // If this coroutine come first and successfully updated the order status then continue the routine
   const won = await Order.findOneAndUpdate(
     { _id: order._id, status: { $ne: 'SUCCESS' } },
-    {
-      $set: {
-        status: 'SUCCESS',
-        routing_fee: payment.fee,
-        payout_hash: payment.id,
-        payout_preimage: payment.secret,
-      },
-    },
+    { $set: update },
   );
   if (won === null) return false;
   // Keep the in-memory document consistent for any later save by the caller.
@@ -45,6 +51,7 @@ export const completeOrderAsSuccess = async (
   order.routing_fee = payment.fee;
   order.payout_hash = payment.id;
   order.payout_preimage = payment.secret;
+  if (paidInvoice) order.buyer_invoice_paid = paidInvoice;
 
   if (pending) {
     pending.paid = true;
@@ -88,6 +95,9 @@ export const healConfirmedOrder = async (
   order: IOrder,
   status: PaymentStatus,
   pending?: IPendingPayment,
+  // Invoice that was actually paid (see completeOrderAsSuccess). Forwarded so a
+  // payout healed on confirmation still records the real invoice. See #864.
+  paidInvoice?: string,
 ): Promise<boolean> => {
   const buyerUser = await User.findOne({ _id: order.buyer_id });
   if (buyerUser === null) throw Error('buyerUser was not found in DB');
@@ -103,6 +113,7 @@ export const healConfirmedOrder = async (
       sellerUser,
       i18nCtx,
       pending,
+      paidInvoice,
     );
     return true;
   }


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where retried payments were overwriting the original buyer invoice, losing audit trail information. The solution introduces a new `buyer_invoice_paid` field to track the invoice that was actually paid while preserving the original `buyer_invoice` for reconciliation and debugging.

## Key Changes

- **New field `buyer_invoice_paid`**: Added to the Order schema to store the invoice that was actually paid, separate from the original `buyer_invoice`
- **Updated `completeOrderAsSuccess`**: Now accepts an optional `paidInvoice` parameter that is recorded atomically in the database update, ensuring the paid invoice is captured without losing the original
- **Updated `healConfirmedOrder`**: Now forwards the paid invoice information through the call chain so confirmed orders also record the real paid invoice
- **Enhanced pending payment retry logic**: The `attemptPendingPayments` job now passes the actual paid invoice (`pending.payment_request`) to completion routines in three scenarios:
  - When the original invoice is already confirmed
  - When a previous pending payment is discovered to be paid
  - When the current pending payment confirms successfully
- **Improved logging**: Enhanced log message to include the actual payment hash (`payment.id`) instead of the hold invoice hash for clarity
- **Updated invoice submission flow**: The `/setinvoice` scene now records the submitted invoice as the paid invoice when healing a confirmed order

## Implementation Details

- The `paidInvoice` parameter is optional to maintain backward compatibility
- Database updates use atomic `$set` operations to ensure consistency
- In-memory order objects are kept synchronized with database state
- All three code paths that complete orders successfully now properly track which invoice was actually paid
- Comprehensive test coverage added for both the job retry logic and the completion routine

## Testing
Added regression tests covering:
- Successful retry payment recording the new invoice in `buyer_invoice_paid` while preserving the original
- Failed payment attempts leaving both invoice fields untouched
- Atomic database updates with proper field isolation
- Race condition handling when multiple processes attempt completion

https://claude.ai/code/session_01Pid19awYpjQUa2cRZKnRaD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orders now persist a separate `buyer_invoice_paid` value to record the invoice that was actually paid, while preserving the original `buyer_invoice`.
* **Bug Fixes**
  * Payment reconciliation for confirmed and retried payments now records the correct paid invoice and avoids overwriting the original buyer invoice.
  * Success handling now reports the real confirmed payment details and updates routing fee from the confirmed payment.
* **Tests**
  * Added regression tests covering successful/failed payment retries, invoice preservation, and compare-and-set behavior to prevent race-condition inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->