### PR TITLE
fix: correct enviroment to environment in bot/scenes.ts

### DIFF
--- a/bot/scenes.ts
+++ b/bot/scenes.ts
@@ -27,7 +27,7 @@ const addInvoiceWizard = new Scenes.WizardScene(
         process.env.HOLD_INVOICE_EXPIRATION_WINDOW;
       if (holdInvoiceExpirationWindow === undefined)
         throw new Error(
-          'Enviroment variable HOLD_INVOICE_EXPIRATION_WINDOW not defined',
+          'Environment variable HOLD_INVOICE_EXPIRATION_WINDOW not defined',
         );
       const expirationTime = parseInt(holdInvoiceExpirationWindow) / 60;
       await messages.wizardAddInvoiceInitMessage(


### PR DESCRIPTION
Corrects the typo 'Enviroment' to 'Environment' in error message.

Author: Jah-yee <jydu_seven@outlook.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in an error message referring to an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->