### PR TITLE
Fix/cancel orders expired holdinvoice continued

### DIFF
--- a/jobs/cancel_orders.ts
+++ b/jobs/cancel_orders.ts
@@ -1,6 +1,7 @@
 import { HasTelegram } from '../bot/start';
 import { User, Order } from '../models';
 import { cancelShowHoldInvoice, cancelAddInvoice } from '../bot/commands';
+import { cancelHoldInvoice } from '../ln';
 import * as messages from '../bot/messages';
 import {
   getUserI18nContext,
@@ -116,10 +117,41 @@ const cancelOrders = async (bot: HasTelegram) => {
       ],
     });
     for (const order of expiredOrders) {
-      order.status = 'EXPIRED';
-      await order.save();
-      OrderEvents.orderUpdated(order);
-      logger.info(`Order Id ${order.id} expired!`);
+      await PerOrderIdMutex.instance.runExclusive(
+        String(order._id),
+        async () => {
+          const updatedOrder = await Order.findById(order._id);
+          if (!updatedOrder) return;
+          // Don't stomp an order that advanced after the find above (e.g. a
+          // release/payout currently in flight under the same mutex).
+          if (
+            updatedOrder.status !== 'ACTIVE' &&
+            updatedOrder.status !== 'FIAT_SENT'
+          )
+            return;
+
+          // For ACTIVE orders the buyer never signalled fiat-sent, so it is
+          // safe to cancel the hold invoice and refund the seller instead of
+          // orphaning the hash. check_hold_invoice_expired ignores EXPIRED
+          // orders, so without this the seller's funds would stay locked until
+          // the on-chain CLTV timeout. FIAT_SENT orders are NOT auto-refunded
+          // here (the buyer claims to have paid) and are left for the
+          // dispute/admin flow.
+          if (updatedOrder.status === 'ACTIVE' && updatedOrder.hash) {
+            await cancelHoldInvoice({ hash: updatedOrder.hash });
+          } else if (updatedOrder.status === 'FIAT_SENT' && updatedOrder.hash) {
+            logger.warning(
+              `Order Id ${updatedOrder.id} expired in FIAT_SENT with an open ` +
+                `hold invoice; leaving it for dispute/admin handling`,
+            );
+          }
+
+          updatedOrder.status = 'EXPIRED';
+          await updatedOrder.save();
+          OrderEvents.orderUpdated(updatedOrder);
+          logger.info(`Order Id ${updatedOrder.id} expired!`);
+        },
+      );
     }
   } catch (error) {
     logger.error(error);

--- a/jobs/cancel_orders.ts
+++ b/jobs/cancel_orders.ts
@@ -139,6 +139,32 @@ const cancelOrders = async (bot: HasTelegram) => {
           // dispute/admin flow.
           if (updatedOrder.status === 'ACTIVE' && updatedOrder.hash) {
             await cancelHoldInvoice({ hash: updatedOrder.hash });
+
+            // The seller's sats are no longer in escrow: warn both parties so
+            // the buyer doesn't send fiat off-platform expecting the hold
+            // invoice to still be backing the trade.
+            const buyerUser = await User.findOne({
+              _id: updatedOrder.buyer_id,
+            });
+            const sellerUser = await User.findOne({
+              _id: updatedOrder.seller_id,
+            });
+            if (buyerUser !== null && sellerUser !== null) {
+              const i18nCtxBuyer = await getUserI18nContext(buyerUser);
+              const i18nCtxSeller = await getUserI18nContext(sellerUser);
+              await messages.toBuyerHoldInvoiceExpiredMessage(
+                bot,
+                buyerUser,
+                updatedOrder,
+                i18nCtxBuyer,
+              );
+              await messages.toSellerHoldInvoiceExpiredMessage(
+                bot,
+                sellerUser,
+                updatedOrder,
+                i18nCtxSeller,
+              );
+            }
           } else if (updatedOrder.status === 'FIAT_SENT' && updatedOrder.hash) {
             logger.warning(
               `Order Id ${updatedOrder.id} expired in FIAT_SENT with an open ` +

--- a/jobs/cancel_orders.ts
+++ b/jobs/cancel_orders.ts
@@ -138,8 +138,16 @@ const cancelOrders = async (bot: HasTelegram) => {
           // here (the buyer claims to have paid) and are left for the
           // dispute/admin flow.
           if (updatedOrder.status === 'ACTIVE' && updatedOrder.hash) {
-            await cancelHoldInvoice({ hash: updatedOrder.hash });
+            try {
+              await cancelHoldInvoice({ hash: updatedOrder.hash });
+            } catch (error) {
+              logger.error(
+                `Order Id ${updatedOrder.id}: failed to cancel hold invoice, will retry on next run: ${error}`,
+              );
+              return; // leave the order ACTIVE so the next run retries it
+            }
 
+            // Only reached if the cancellation succeeded.
             // The seller's sats are no longer in escrow: warn both parties so
             // the buyer doesn't send fiat off-platform expecting the hold
             // invoice to still be backing the trade.

--- a/ln/hold_invoice.ts
+++ b/ln/hold_invoice.ts
@@ -56,6 +56,9 @@ const cancelHoldInvoice = async ({ hash }: { hash: string }) => {
     await lightning.cancelHodlInvoice({ lnd, id: hash });
   } catch (error) {
     logger.error(error);
+    // Callers must not mark an order as canceled/expired if the
+    // invoice cancellation did not happen.
+    throw error;
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lnp2pbot",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lnp2pbot",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@grammyjs/i18n": "^0.5.1",

--- a/tests/jobs/cancel_orders.spec.ts
+++ b/tests/jobs/cancel_orders.spec.ts
@@ -67,7 +67,8 @@ describe('Job: cancel_orders (ACTIVE hold invoice cancellation branch)', () => {
         toBuyerExpiredOrderMessage: sandbox.stub().resolves(),
         toSellerExpiredOrderMessage: sandbox.stub().resolves(),
         toBuyerHoldInvoiceExpiredMessage: toBuyerHoldInvoiceExpiredMessageStub,
-        toSellerHoldInvoiceExpiredMessage: toSellerHoldInvoiceExpiredMessageStub,
+        toSellerHoldInvoiceExpiredMessage:
+          toSellerHoldInvoiceExpiredMessageStub,
       },
       '../util': {
         getUserI18nContext: getUserI18nContextStub,

--- a/tests/jobs/cancel_orders.spec.ts
+++ b/tests/jobs/cancel_orders.spec.ts
@@ -1,0 +1,195 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+proxyquire.noCallThru();
+
+describe('Job: cancel_orders (ACTIVE hold invoice cancellation branch)', () => {
+  let sandbox: any;
+  let cancelOrders: any;
+
+  let orderFindStub: any;
+  let orderFindByIdStub: any;
+  let userFindOneStub: any;
+  let cancelHoldInvoiceStub: any;
+  let toBuyerHoldInvoiceExpiredMessageStub: any;
+  let toSellerHoldInvoiceExpiredMessageStub: any;
+  let orderUpdatedStub: any;
+  let loggerWarningStub: any;
+  let loggerErrorStub: any;
+  let getUserI18nContextStub: any;
+
+  let expiredOrders: any[];
+  let updatedOrder: any;
+
+  const buyerUser = { _id: 'buyer1' };
+  const sellerUser = { _id: 'seller1' };
+  const i18nCtx = { t: (key: string) => key };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    orderFindByIdStub = sandbox.stub().callsFake(async () => updatedOrder);
+
+    // The job runs three separate Order.find queries; only the "expired
+    // orders" query (no `$and`, no `admin_warned`) is relevant here.
+    orderFindStub = sandbox.stub().callsFake(async (query: any) => {
+      if (query && ('$and' in query || 'admin_warned' in query)) return [];
+      return expiredOrders;
+    });
+
+    userFindOneStub = sandbox.stub().callsFake(async ({ _id }: any) => {
+      if (_id === 'buyer1') return buyerUser;
+      if (_id === 'seller1') return sellerUser;
+      return null;
+    });
+
+    cancelHoldInvoiceStub = sandbox.stub().resolves();
+    toBuyerHoldInvoiceExpiredMessageStub = sandbox.stub().resolves();
+    toSellerHoldInvoiceExpiredMessageStub = sandbox.stub().resolves();
+    orderUpdatedStub = sandbox.stub();
+    loggerWarningStub = sandbox.stub();
+    loggerErrorStub = sandbox.stub();
+    getUserI18nContextStub = sandbox.stub().resolves(i18nCtx);
+
+    const jobModule = proxyquire('../../jobs/cancel_orders', {
+      '../models': {
+        User: { findOne: userFindOneStub },
+        Order: { find: orderFindStub, findById: orderFindByIdStub },
+      },
+      '../bot/commands': {
+        cancelShowHoldInvoice: sandbox.stub().resolves(),
+        cancelAddInvoice: sandbox.stub().resolves(),
+      },
+      '../ln': { cancelHoldInvoice: cancelHoldInvoiceStub },
+      '../bot/messages': {
+        expiredOrderMessage: sandbox.stub().resolves(),
+        toBuyerExpiredOrderMessage: sandbox.stub().resolves(),
+        toSellerExpiredOrderMessage: sandbox.stub().resolves(),
+        toBuyerHoldInvoiceExpiredMessage: toBuyerHoldInvoiceExpiredMessageStub,
+        toSellerHoldInvoiceExpiredMessage: toSellerHoldInvoiceExpiredMessageStub,
+      },
+      '../util': {
+        getUserI18nContext: getUserI18nContextStub,
+        holdInvoiceExpirationInSecs: () => ({
+          expirationTimeInSecs: 0,
+          safetyWindowInSecs: 0,
+        }),
+        PerOrderIdMutex: {
+          instance: {
+            runExclusive: async (_id: string, cb: () => Promise<any>) => cb(),
+          },
+        },
+      },
+      '../logger': {
+        logger: {
+          error: loggerErrorStub,
+          warning: loggerWarningStub,
+          info: sandbox.stub(),
+        },
+      },
+      '../bot/modules/events/orders': { orderUpdated: orderUpdatedStub },
+    });
+
+    cancelOrders = jobModule.default;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('marks an ACTIVE order with a hash as EXPIRED when cancelHoldInvoice succeeds', async () => {
+    updatedOrder = {
+      _id: 'order1',
+      id: 'order1',
+      status: 'ACTIVE',
+      hash: 'hash1',
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      save: sandbox.stub().resolves(),
+    };
+    expiredOrders = [{ _id: 'order1' }];
+
+    await cancelOrders({} as any);
+
+    expect(cancelHoldInvoiceStub.calledOnceWith({ hash: 'hash1' })).to.equal(
+      true,
+    );
+    expect(updatedOrder.status).to.equal('EXPIRED');
+    expect(updatedOrder.save.calledOnce).to.equal(true);
+    expect(toBuyerHoldInvoiceExpiredMessageStub.calledOnce).to.equal(true);
+    expect(toSellerHoldInvoiceExpiredMessageStub.calledOnce).to.equal(true);
+    expect(orderUpdatedStub.calledOnceWith(updatedOrder)).to.equal(true);
+  });
+
+  it('leaves the order ACTIVE and sends no messages when cancelHoldInvoice throws', async () => {
+    updatedOrder = {
+      _id: 'order1',
+      id: 'order1',
+      status: 'ACTIVE',
+      hash: 'hash1',
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      save: sandbox.stub().resolves(),
+    };
+    expiredOrders = [{ _id: 'order1' }];
+    cancelHoldInvoiceStub.rejects(new Error('LND error: unable to cancel'));
+
+    await cancelOrders({} as any);
+
+    expect(cancelHoldInvoiceStub.calledOnceWith({ hash: 'hash1' })).to.equal(
+      true,
+    );
+    expect(updatedOrder.status).to.equal('ACTIVE');
+    expect(updatedOrder.save.called).to.equal(false);
+    expect(toBuyerHoldInvoiceExpiredMessageStub.called).to.equal(false);
+    expect(toSellerHoldInvoiceExpiredMessageStub.called).to.equal(false);
+    expect(orderUpdatedStub.called).to.equal(false);
+  });
+
+  it('marks an ACTIVE order without a hash as EXPIRED without calling cancelHoldInvoice', async () => {
+    updatedOrder = {
+      _id: 'order1',
+      id: 'order1',
+      status: 'ACTIVE',
+      hash: null,
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      save: sandbox.stub().resolves(),
+    };
+    expiredOrders = [{ _id: 'order1' }];
+
+    await cancelOrders({} as any);
+
+    expect(cancelHoldInvoiceStub.called).to.equal(false);
+    expect(updatedOrder.status).to.equal('EXPIRED');
+    expect(updatedOrder.save.calledOnce).to.equal(true);
+    expect(orderUpdatedStub.calledOnceWith(updatedOrder)).to.equal(true);
+  });
+
+  it('marks a FIAT_SENT order as EXPIRED without calling cancelHoldInvoice, warning instead', async () => {
+    updatedOrder = {
+      _id: 'order1',
+      id: 'order1',
+      status: 'FIAT_SENT',
+      hash: 'hash1',
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      save: sandbox.stub().resolves(),
+    };
+    expiredOrders = [{ _id: 'order1' }];
+
+    await cancelOrders({} as any);
+
+    expect(cancelHoldInvoiceStub.called).to.equal(false);
+    expect(loggerWarningStub.calledOnce).to.equal(true);
+    expect(loggerWarningStub.firstCall.args[0]).to.match(
+      /dispute\/admin handling/,
+    );
+    expect(updatedOrder.status).to.equal('EXPIRED');
+    expect(updatedOrder.save.calledOnce).to.equal(true);
+    expect(orderUpdatedStub.calledOnceWith(updatedOrder)).to.equal(true);
+  });
+});
+
+export {};

--- a/tests/jobs/cancel_orders.spec.ts
+++ b/tests/jobs/cancel_orders.spec.ts
@@ -168,6 +168,29 @@ describe('Job: cancel_orders (ACTIVE hold invoice cancellation branch)', () => {
     expect(orderUpdatedStub.calledOnceWith(updatedOrder)).to.equal(true);
   });
 
+  it('does not touch an order that already advanced past ACTIVE/FIAT_SENT by the time the mutex runs', async () => {
+    // expiredOrders is a stale snapshot taken before the mutex lock; the
+    // job re-fetches with Order.findById() inside the mutex and must bail
+    // out if the status changed underneath it (e.g. it was released).
+    updatedOrder = {
+      _id: 'order1',
+      id: 'order1',
+      status: 'COMPLETED',
+      hash: 'hash1',
+      buyer_id: 'buyer1',
+      seller_id: 'seller1',
+      save: sandbox.stub().resolves(),
+    };
+    expiredOrders = [{ _id: 'order1' }];
+
+    await cancelOrders({} as any);
+
+    expect(cancelHoldInvoiceStub.called).to.equal(false);
+    expect(updatedOrder.status).to.equal('COMPLETED');
+    expect(updatedOrder.save.called).to.equal(false);
+    expect(orderUpdatedStub.called).to.equal(false);
+  });
+
   it('marks a FIAT_SENT order as EXPIRED without calling cancelHoldInvoice, warning instead', async () => {
     updatedOrder = {
       _id: 'order1',


### PR DESCRIPTION
## Summary

Continues #837 (originally by @grunch).

Ensures that when the cancel-orders job expires an `ACTIVE` order, the associated Lightning hold invoice is canceled so the seller's locked funds are refunded promptly, instead of being orphaned until the on-chain CLTV timeout. The expiry transition is serialized under the per-order mutex with a state re-check to avoid racing concurrent flows.

Previously, the job marked expired orders as `EXPIRED` without canceling the hold invoice. Because the expired-hold-invoice check ignores `EXPIRED` orders, the seller's funds remained locked until the on-chain timeout.

## Changes

- **`jobs/cancel_orders.ts`** — Run the expiry transition inside `PerOrderIdMutex.instance.runExclusive(orderId, ...)` and re-read the order under the lock so the job does not stomp an order that advanced concurrently. Only `ACTIVE` and `FIAT_SENT` orders are expired:
  - `ACTIVE` — the buyer never signalled fiat-sent, so cancel the hold invoice (refund the seller) before marking the order `EXPIRED`, and notify both buyer and seller that the sats are no longer in escrow. This addresses @Luquitasjeffrey's review comment on #837: without the notification, a malicious seller could keep the fiat payment after the order expired silently, since the buyer would have no way of knowing the escrow was no longer backing the trade.
  - `FIAT_SENT` — the buyer claims to have paid; the hold invoice is left open and the case is logged for the dispute/admin flow rather than auto-refunded.

- **`ln/hold_invoice.ts`** — `cancelHoldInvoice` now re-throws LND errors instead of swallowing them, consistent with `settleHoldInvoice` which already had this behavior with the comment *"Callers must not mark an order as settled/frozen if the invoice settlement did not happen."* The same reasoning applies here: callers must not mark an order `EXPIRED` if the hold invoice cancellation did not happen. This is a prerequisite for the error handling in `cancel_orders.ts` to work correctly — if `cancelHoldInvoice` fails, the `ACTIVE` order is left untouched so the next job run retries the cancellation rather than silently leaving the seller's funds locked.

  **Behavior change for other call sites:** `cancelHoldInvoice` is also called from `bot/commands.ts` (cooperative cancel, seller cancel, admin cancel) and `bot/start.ts`. All of these are wrapped in outer `try/catch` blocks that log the error. With this change, a LND failure during those flows will now abort the operation silently instead of proceeding with inconsistent state (e.g. marking an order `CANCELED` while its hold invoice is still live). The order stays in its previous state and the user can retry — safer than before, but without user-facing feedback on failure. A follow-up issue will address surfacing an error message to the user in these cases.

## Testing

Manually tested end-to-end against a local regtest LND setup (temporarily lowering `ORDER_PUBLISHED_EXPIRATION_WINDOW`/`HOLD_INVOICE_EXPIRATION_WINDOW` to speed up expiry):

- [x] Sell order happy path
- [x] Buy order happy path
- [x] `ACTIVE` order expiry: hold invoice canceled in LND (confirmed via `subscribeInvoice` terminal state `canceled=true`), both parties notified
- [x] `FIAT_SENT` order expiry: hold invoice left open, warning logged, left for dispute/admin
- [x] `WAITING_PAYMENT` / `WAITING_BUYER_INVOICE` expiry
- [x] Dispute flow
- [x] Cooperative cancellation
- [x] `npx tsc --noEmit`, `eslint`, `prettier --check` pass on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved expired-order processing for active orders with outstanding hold invoices.
  - Eligible orders are refunded, both parties are notified, and status updates are applied consistently.
  - Orders where fiat has already been sent are preserved for dispute handling rather than automatically refunded.
  - Failed invoice cancellations are now reported correctly, preventing orders from being marked as successfully completed when cancellation does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->