### PR TITLE
fix: support socks5h:// scheme in SOCKS_PROXY_HOST regex

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -50,7 +50,7 @@ import { startMonitoring } from './monitoring';
         const socksProxyHost = process.env.SOCKS_PROXY_HOST?.trim();
         const telegramAgent = socksProxyHost
           ? (() => {
-              const proxyUrl = /^socks[45]?:\/\//i.test(socksProxyHost)
+              const proxyUrl = /^socks[45]?h?:\/\//i.test(socksProxyHost)
                 ? socksProxyHost
                 : `socks5://${socksProxyHost}`;
               logger.info(`Using SOCKS proxy for Telegram API: ${proxyUrl}`);

--- a/app.ts
+++ b/app.ts
@@ -50,7 +50,9 @@ import { startMonitoring } from './monitoring';
         const socksProxyHost = process.env.SOCKS_PROXY_HOST?.trim();
         const telegramAgent = socksProxyHost
           ? (() => {
-              const proxyUrl = /^socks[45]?h?:\/\//i.test(socksProxyHost)
+              const proxyUrl = /^(?:socks|socks4|socks5|socks5h):\/\//i.test(
+                socksProxyHost,
+              )
                 ? socksProxyHost
                 : `socks5://${socksProxyHost}`;
               logger.info(`Using SOCKS proxy for Telegram API: ${proxyUrl}`);

--- a/app.ts
+++ b/app.ts
@@ -7,7 +7,7 @@ import { connect as mongoConnect } from './db_connect';
 import { resubscribeInvoices } from './ln';
 import { logger } from './logger';
 import { Telegraf } from 'telegraf';
-import { delay } from './util';
+import { delay, buildSocksProxyUrl } from './util';
 import { imageCache } from './util/imageCache';
 import { createIndexes } from './models/indexes';
 import { CommunityContext } from './bot/modules/community/communityContext';
@@ -50,11 +50,7 @@ import { startMonitoring } from './monitoring';
         const socksProxyHost = process.env.SOCKS_PROXY_HOST?.trim();
         const telegramAgent = socksProxyHost
           ? (() => {
-              const proxyUrl = /^(?:socks|socks4|socks5|socks5h):\/\//i.test(
-                socksProxyHost,
-              )
-                ? socksProxyHost
-                : `socks5://${socksProxyHost}`;
+              const proxyUrl = buildSocksProxyUrl(socksProxyHost);
               logger.info(`Using SOCKS proxy for Telegram API: ${proxyUrl}`);
               return new SocksProxyAgent(proxyUrl) as any;
             })()

--- a/tests/util/index.spec.ts
+++ b/tests/util/index.spec.ts
@@ -8,6 +8,7 @@ import {
   toKebabCase,
   getDetailedOrder,
   getUserI18nContext,
+  buildSocksProxyUrl,
 } from '../../util/index';
 
 const { expect } = require('chai');
@@ -220,6 +221,35 @@ describe('Utility Functions', () => {
     it('falls back to English when lang is missing', async () => {
       const ctx = await getUserI18nContext({} as any);
       expect(ctx.locale()).to.equal('en');
+    });
+  });
+
+  describe('buildSocksProxyUrl', () => {
+    // Guards a regression (#826) where socks5h:// (used with Tor to resolve
+    // DNS through the proxy) was treated as a bare host and got a scheme
+    // prepended twice, producing an invalid URL like socks5://socks5h://...
+    ['socks', 'socks4', 'socks5', 'socks5h'].forEach(scheme => {
+      it(`passes through URLs with the ${scheme}:// scheme unchanged`, () => {
+        const url = `${scheme}://localhost:9050`;
+        expect(buildSocksProxyUrl(url)).to.equal(url);
+      });
+    });
+
+    it('is case-insensitive when matching the scheme', () => {
+      const url = 'SOCKS5H://localhost:9050';
+      expect(buildSocksProxyUrl(url)).to.equal(url);
+    });
+
+    it('prepends socks5:// to a bare host with no scheme', () => {
+      expect(buildSocksProxyUrl('localhost:9050')).to.equal(
+        'socks5://localhost:9050',
+      );
+    });
+
+    it('prepends socks5:// to an unsupported scheme, such as socks4h', () => {
+      expect(buildSocksProxyUrl('socks4h://localhost:9050')).to.equal(
+        'socks5://socks4h://localhost:9050',
+      );
     });
   });
 });

--- a/util/index.ts
+++ b/util/index.ts
@@ -605,6 +605,12 @@ export const removeLightningPrefix = (invoice: string) => {
   return invoice;
 };
 
+export const buildSocksProxyUrl = (socksProxyHost: string) => {
+  return /^(?:socks|socks4|socks5|socks5h):\/\//i.test(socksProxyHost)
+    ? socksProxyHost
+    : `socks5://${socksProxyHost}`;
+};
+
 const generateRandomImage = (nonce: string) => {
   // Import imageCache here to avoid circular dependency
   const { imageCache } = require('./imageCache');


### PR DESCRIPTION
Fixes SOCKS_PROXY_HOST regex to match the `socks5h://` scheme (regression from #826), found while testing #885.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SOCKS proxy URL validation now supports the `socks`, `socks4`, `socks5`, and `socks5h` schemes.
  * The unsupported `socks4h` scheme now receives the default `socks5://` prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->