### PR TITLE
ci: make pushing a tag the only manual release step

### DIFF
--- a/.github/scripts/release-sync.mjs
+++ b/.github/scripts/release-sync.mjs
@@ -66,7 +66,10 @@ const readJsonFile = async path => {
   return { sha: file.sha, data: JSON.parse(text) };
 };
 
-const commitJsonFile = async (path, sha, data, message) => {
+// The blob sha only guards against a concurrent change to this same file, so
+// also assert what the new commit was built on: anything else means the branch
+// moved and the release would carry commits the tag never covered.
+const commitJsonFile = async (path, sha, data, message, expectedParent) => {
   const content = Buffer.from(
     `${JSON.stringify(data, null, 2)}\n`,
     'utf8'
@@ -75,6 +78,12 @@ const commitJsonFile = async (path, sha, data, message) => {
     method: 'PUT',
     body: JSON.stringify({ message, content, sha, branch }),
   });
+  const parent = result.commit.parents?.[0]?.sha;
+  if (parent !== expectedParent) {
+    throw new Error(
+      `Commit for ${path} was built on ${parent} instead of ${expectedParent}; ${branch} moved mid-release`
+    );
+  }
   console.log(`${message} (${result.commit.sha})`);
   return result.commit.sha;
 };
@@ -83,8 +92,9 @@ const commitJsonFile = async (path, sha, data, message) => {
 // moved onto it. Unless the tag already points at that same head, moving it
 // would pull commits into the release that were never tagged, so require an
 // exact match: "ahead" means the tag is not merged, "behind" means the branch
-// moved on after tagging, and both need a human decision.
-const assertTagIsBranchHead = async () => {
+// moved on after tagging, and both need a human decision. Returns the head the
+// bump commits must build on.
+const resolveReleaseHead = async () => {
   const { status } = await api(
     `/compare/${encodeURIComponent(branch)}...${encodeURIComponent(tag)}`
   );
@@ -93,20 +103,23 @@ const assertTagIsBranchHead = async () => {
       `Tag ${tag} is "${status}" relative to ${branch}; tag the current ${branch} head`
     );
   }
+  const { sha } = await api(`/commits/${encodeURIComponent(branch)}`);
+  return sha;
 };
 
-const bumpPackageJson = async () => {
+const bumpPackageJson = async parent => {
   const { sha, data } = await readJsonFile('package.json');
   if (data.version === version) return null;
   return commitJsonFile(
     'package.json',
     sha,
     { ...data, version },
-    `chore: bump package.json to ${tag}`
+    `chore: bump package.json to ${tag}`,
+    parent
   );
 };
 
-const bumpPackageLock = async () => {
+const bumpPackageLock = async parent => {
   const { sha, data } = await readJsonFile('package-lock.json');
   const root = data.packages?.[''];
   if (data.version === version && root?.version === version) return null;
@@ -121,7 +134,8 @@ const bumpPackageLock = async () => {
     'package-lock.json',
     sha,
     next,
-    `chore: sync package-lock.json to ${tag}`
+    `chore: sync package-lock.json to ${tag}`,
+    parent
   );
 };
 
@@ -133,16 +147,16 @@ const repointTag = async sha => {
   console.log(`Tag ${tag} now points at ${sha}`);
 };
 
-await assertTagIsBranchHead();
+const taggedHead = await resolveReleaseHead();
 
 // Sequential on purpose: each Contents API commit must build on the previous
-// one, and a concurrent PUT would fail on a stale blob sha.
-const packageJsonCommit = await bumpPackageJson();
-const packageLockCommit = await bumpPackageLock();
-const lastCommit = packageLockCommit || packageJsonCommit;
+// one, so each call also becomes the expected parent of the next.
+let head = taggedHead;
+head = (await bumpPackageJson(head)) ?? head;
+head = (await bumpPackageLock(head)) ?? head;
 
-if (lastCommit) {
-  await repointTag(lastCommit);
-} else {
+if (head === taggedHead) {
   console.log(`Version files already at ${version}; tag left untouched`);
+} else {
+  await repointTag(head);
 }

--- a/.github/scripts/release-sync.mjs
+++ b/.github/scripts/release-sync.mjs
@@ -1,0 +1,127 @@
+// Syncs the repository to the version carried by a release tag.
+//
+// Run from the Release workflow when a `v*` tag is pushed. It bumps
+// package.json and package-lock.json on the default branch and re-points the
+// tag at the resulting commit, so pushing the tag is the only manual step.
+//
+// Commits go through the Contents API instead of `git push` because the
+// default branch requires signed commits, and only API-created commits are
+// signed by GitHub.
+
+const API = 'https://api.github.com';
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY;
+const tag = process.env.TAG;
+const branch = process.env.BRANCH || 'main';
+
+if (!token || !repo || !tag) {
+  throw new Error('GITHUB_TOKEN, GITHUB_REPOSITORY and TAG are required');
+}
+
+const version = tag.replace(/^v/, '');
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error(`Tag "${tag}" must look like vMAJOR.MINOR.PATCH`);
+}
+
+const api = async (path, init = {}) => {
+  const res = await fetch(`${API}/repos/${repo}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: 'application/vnd.github+json',
+      'content-type': 'application/json',
+      ...init.headers,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${init.method || 'GET'} ${path} -> ${res.status} ${await res.text()}`
+    );
+  }
+  return res.json();
+};
+
+const readJsonFile = async path => {
+  const file = await api(`/contents/${path}?ref=${branch}`);
+  const text = Buffer.from(file.content, 'base64').toString('utf8');
+  return { sha: file.sha, data: JSON.parse(text) };
+};
+
+const commitJsonFile = async (path, sha, data, message) => {
+  const content = Buffer.from(
+    `${JSON.stringify(data, null, 2)}\n`,
+    'utf8'
+  ).toString('base64');
+  const result = await api(`/contents/${path}`, {
+    method: 'PUT',
+    body: JSON.stringify({ message, content, sha, branch }),
+  });
+  console.log(`${message} (${result.commit.sha})`);
+  return result.commit.sha;
+};
+
+// A tag pointing at a commit that never reached the default branch would make
+// the bump commit graft unrelated history onto the release, so refuse it.
+const assertTagIsOnBranch = async () => {
+  const { status } = await api(
+    `/compare/${encodeURIComponent(branch)}...${encodeURIComponent(tag)}`
+  );
+  if (status !== 'identical' && status !== 'behind') {
+    throw new Error(
+      `Tag ${tag} is "${status}" relative to ${branch}; tag a commit that is already merged`
+    );
+  }
+};
+
+const bumpPackageJson = async () => {
+  const { sha, data } = await readJsonFile('package.json');
+  if (data.version === version) return null;
+  return commitJsonFile(
+    'package.json',
+    sha,
+    { ...data, version },
+    `chore: bump package.json to ${tag}`
+  );
+};
+
+const bumpPackageLock = async () => {
+  const { sha, data } = await readJsonFile('package-lock.json');
+  const root = data.packages?.[''];
+  if (data.version === version && root?.version === version) return null;
+  const next = {
+    ...data,
+    version,
+    ...(root && {
+      packages: { ...data.packages, '': { ...root, version } },
+    }),
+  };
+  return commitJsonFile(
+    'package-lock.json',
+    sha,
+    next,
+    `chore: sync package-lock.json to ${tag}`
+  );
+};
+
+const repointTag = async sha => {
+  await api(`/git/refs/tags/${tag}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ sha, force: true }),
+  });
+  console.log(`Tag ${tag} now points at ${sha}`);
+};
+
+await assertTagIsOnBranch();
+
+// Sequential on purpose: each Contents API commit must build on the previous
+// one, and a concurrent PUT would fail on a stale blob sha.
+const packageJsonCommit = await bumpPackageJson();
+const packageLockCommit = await bumpPackageLock();
+const lastCommit = packageLockCommit || packageJsonCommit;
+
+if (lastCommit) {
+  await repointTag(lastCommit);
+} else {
+  console.log(`Version files already at ${version}; tag left untouched`);
+}

--- a/.github/scripts/release-sync.mjs
+++ b/.github/scripts/release-sync.mjs
@@ -19,9 +19,17 @@ if (!token || !repo || !tag) {
   throw new Error('GITHUB_TOKEN, GITHUB_REPOSITORY and TAG are required');
 }
 
+// MAJOR.MINOR.PATCH with the optional prerelease and build metadata that the
+// `v*` workflow trigger also accepts, e.g. v1.2.3-rc.1 or v1.2.3+build.5.
+const SEMVER =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const REQUEST_TIMEOUT_MS = 30_000;
+
 const version = tag.replace(/^v/, '');
-if (!/^\d+\.\d+\.\d+$/.test(version)) {
-  throw new Error(`Tag "${tag}" must look like vMAJOR.MINOR.PATCH`);
+if (!SEMVER.test(version)) {
+  throw new Error(
+    `Tag "${tag}" must look like vMAJOR.MINOR.PATCH[-prerelease][+build]`
+  );
 }
 
 const api = async (path, init = {}) => {
@@ -33,6 +41,9 @@ const api = async (path, init = {}) => {
       'content-type': 'application/json',
       ...init.headers,
     },
+    // Without this a stalled connection would hang the job until its own
+    // timeout hours later.
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!res.ok) {
     throw new Error(
@@ -44,6 +55,13 @@ const api = async (path, init = {}) => {
 
 const readJsonFile = async path => {
   const file = await api(`/contents/${path}?ref=${branch}`);
+  // Files above 1 MB come back with an empty body and encoding "none", which
+  // would otherwise surface as an opaque JSON parse error.
+  if (file.encoding !== 'base64') {
+    throw new Error(
+      `${path} came back with encoding "${file.encoding}"; it is too large for the Contents API`
+    );
+  }
   const text = Buffer.from(file.content, 'base64').toString('utf8');
   return { sha: file.sha, data: JSON.parse(text) };
 };
@@ -61,15 +79,18 @@ const commitJsonFile = async (path, sha, data, message) => {
   return result.commit.sha;
 };
 
-// A tag pointing at a commit that never reached the default branch would make
-// the bump commit graft unrelated history onto the release, so refuse it.
-const assertTagIsOnBranch = async () => {
+// The bump commit is created on top of the branch head, and the tag is then
+// moved onto it. Unless the tag already points at that same head, moving it
+// would pull commits into the release that were never tagged, so require an
+// exact match: "ahead" means the tag is not merged, "behind" means the branch
+// moved on after tagging, and both need a human decision.
+const assertTagIsBranchHead = async () => {
   const { status } = await api(
     `/compare/${encodeURIComponent(branch)}...${encodeURIComponent(tag)}`
   );
-  if (status !== 'identical' && status !== 'behind') {
+  if (status !== 'identical') {
     throw new Error(
-      `Tag ${tag} is "${status}" relative to ${branch}; tag a commit that is already merged`
+      `Tag ${tag} is "${status}" relative to ${branch}; tag the current ${branch} head`
     );
   }
 };
@@ -112,7 +133,7 @@ const repointTag = async sha => {
   console.log(`Tag ${tag} now points at ${sha}`);
 };
 
-await assertTagIsOnBranch();
+await assertTagIsBranchHead();
 
 // Sequential on purpose: each Contents API commit must build on the previous
 // one, and a concurrent PUT would fail on a stale blob sha.

--- a/.github/scripts/release-sync.mjs
+++ b/.github/scripts/release-sync.mjs
@@ -6,7 +6,16 @@
 //
 // Commits go through the Contents API instead of `git push` because the
 // default branch requires signed commits, and only API-created commits are
-// signed by GitHub.
+// signed by GitHub. Known limits of that API, neither of them reached today:
+// it commits one file at a time, which is why a release adds two commits, and
+// it cannot read or write blobs above 1 MB. package-lock.json is at ~264 KB;
+// when it approaches 1 MB this has to move to the Git Database API, which
+// would also collapse the two commits into one.
+//
+// An annotated tag is recreated over the bump commit so `git tag -a` keeps its
+// message. A *signature* cannot survive this: it covers the object the tag was
+// made on, so moving the tag necessarily invalidates it. Release tags are
+// therefore unsigned by design, and `git tag -s` is downgraded with a warning.
 
 const API = 'https://api.github.com';
 
@@ -24,6 +33,9 @@ if (!token || !repo || !tag) {
 const SEMVER =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const REQUEST_TIMEOUT_MS = 30_000;
+const PACKAGE_JSON_MESSAGE = `chore: bump package.json to ${tag}`;
+const PACKAGE_LOCK_MESSAGE = `chore: sync package-lock.json to ${tag}`;
+const BUMP_MESSAGES = [PACKAGE_JSON_MESSAGE, PACKAGE_LOCK_MESSAGE];
 
 const version = tag.replace(/^v/, '');
 if (!SEMVER.test(version)) {
@@ -99,6 +111,25 @@ const resolveReleaseHead = async () => {
     `/compare/${encodeURIComponent(branch)}...${encodeURIComponent(tag)}`
   );
   if (status !== 'identical') {
+    // A run that died between the bump commits and the re-point leaves exactly
+    // this state, and "tag the current head" alone would not explain it.
+    if (status === 'behind') {
+      const { commits } = await api(
+        `/compare/${encodeURIComponent(tag)}...${encodeURIComponent(branch)}`
+      );
+      const onlyOurBumps =
+        commits.length > 0 &&
+        commits.every(({ commit }) =>
+          BUMP_MESSAGES.some(message => commit.message.startsWith(message))
+        );
+      if (onlyOurBumps) {
+        throw new Error(
+          `An earlier run already bumped the version files for ${tag} but did not finish. ` +
+            `Move the tag onto them and re-run this workflow: ` +
+            `git fetch origin && git tag -f ${tag} origin/${branch} && git push -f origin ${tag}`
+        );
+      }
+    }
     throw new Error(
       `Tag ${tag} is "${status}" relative to ${branch}; tag the current ${branch} head`
     );
@@ -114,7 +145,7 @@ const bumpPackageJson = async parent => {
     'package.json',
     sha,
     { ...data, version },
-    `chore: bump package.json to ${tag}`,
+    PACKAGE_JSON_MESSAGE,
     parent
   );
 };
@@ -134,20 +165,49 @@ const bumpPackageLock = async parent => {
     'package-lock.json',
     sha,
     next,
-    `chore: sync package-lock.json to ${tag}`,
+    PACKAGE_LOCK_MESSAGE,
     parent
   );
 };
 
-const repointTag = async sha => {
+// Read before anything moves the ref, since re-pointing orphans the object.
+const readAnnotation = async () => {
+  const { object } = await api(`/git/ref/tags/${tag}`);
+  if (object.type !== 'tag') return null;
+  const { message, verification } = await api(`/git/tags/${object.sha}`);
+  return { message, signed: Boolean(verification?.signature) };
+};
+
+const repointTag = async (sha, annotation) => {
+  let target = sha;
+  if (annotation) {
+    if (annotation.signed) {
+      console.log(
+        `::warning::${tag} was signed; the release tag cannot carry that signature over to the bump commit`
+      );
+    }
+    const created = await api('/git/tags', {
+      method: 'POST',
+      body: JSON.stringify({
+        tag,
+        message: annotation.message,
+        object: sha,
+        type: 'commit',
+      }),
+    });
+    target = created.sha;
+  }
   await api(`/git/refs/tags/${tag}`, {
     method: 'PATCH',
-    body: JSON.stringify({ sha, force: true }),
+    body: JSON.stringify({ sha: target, force: true }),
   });
-  console.log(`Tag ${tag} now points at ${sha}`);
+  console.log(
+    `Tag ${tag} now points at ${sha}${annotation ? ' (annotation preserved)' : ''}`
+  );
 };
 
 const taggedHead = await resolveReleaseHead();
+const annotation = await readAnnotation();
 
 // Sequential on purpose: each Contents API commit must build on the previous
 // one, so each call also becomes the expected parent of the next.
@@ -158,5 +218,5 @@ head = (await bumpPackageLock(head)) ?? head;
 if (head === taggedHead) {
   console.log(`Version files already at ${version}; tag left untouched`);
 } else {
-  await repointTag(head);
+  await repointTag(head, annotation);
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,13 @@ on:
 permissions:
   contents: write
 
+# Every release run commits to the default branch, so two tags pushed close
+# together must queue instead of interleaving their version bumps. Never
+# cancel: a half-applied release would leave the branch mid-bump.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+# Pushing a `v*` tag is the only manual step: this workflow bumps the version
+# files on main, re-points the tag at that commit and publishes the release.
+
 on:
   push:
     tags:
@@ -13,17 +16,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history plus tags, needed to diff against the previous release.
+          fetch-depth: 0
 
-      - name: Extract changelog for this version
-        id: changelog
+      - name: Sync version files and tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          BRANCH: ${{ github.event.repository.default_branch }}
+        run: node .github/scripts/release-sync.mjs
+
+      - name: Build release notes
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md > /tmp/release-notes.md
+
+          # No hand-written changelog entry for this version: fall back to the
+          # commit subjects since the previous tag.
+          if [ ! -s /tmp/release-notes.md ]; then
+            PREVIOUS_TAG="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
+            RANGE="${GITHUB_REF_NAME}"
+            [ -n "$PREVIOUS_TAG" ] && RANGE="${PREVIOUS_TAG}..${GITHUB_REF_NAME}"
+            {
+              echo "### Changes"
+              echo
+              git log --no-merges --pretty='- %s' "$RANGE"
+            } > /tmp/release-notes.md
+          fi
+
           cat /tmp/release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ github.ref_name }}
           body_path: /tmp/release-notes.md
           generate_release_notes: false
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,22 @@ jobs:
       - name: Build release notes
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md > /tmp/release-notes.md
+
+          # The sync step already rejects anything else, but the tag name is
+          # interpolated into an awk program below, so do not rely on step order
+          # for that.
+          echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$' || {
+            echo "Refusing to build notes for unexpected tag ${GITHUB_REF_NAME}"
+            exit 1
+          }
+          # Dots are regex wildcards in the awk pattern; 0.16.0 must not match 0x16y0.
+          ESCAPED_VERSION="${VERSION//./\\.}"
+
+          awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md > /tmp/release-notes.md
 
           # No hand-written changelog entry for this version: fall back to the
-          # commit subjects since the previous tag.
+          # commit subjects since the previous tag. The version bumps are this
+          # workflow's own noise, so leave them out.
           if [ ! -s /tmp/release-notes.md ]; then
             PREVIOUS_TAG="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
             RANGE="${GITHUB_REF_NAME}"
@@ -48,7 +60,11 @@ jobs:
             {
               echo "### Changes"
               echo
-              git log --no-merges --pretty='- %s' "$RANGE"
+              git log --no-merges --pretty='- %s' \
+                --invert-grep \
+                --grep='^chore: bump package\.json to v' \
+                --grep='^chore: sync package-lock\.json to v' \
+                "$RANGE"
             } > /tmp/release-notes.md
           fi
 


### PR DESCRIPTION
## Summary

Releasing currently means: bump `package.json` + `package-lock.json`, write the `CHANGELOG.md` section, merge, and only then tag. This moves the mechanical part into the workflow so **pushing a `v*` tag is the only manual step**.

The trigger is unchanged — `on: push: tags: ['v*']`, nothing else creates releases.

## Cutting a release

```
git fetch origin && git tag v0.16.0 origin/main && git push origin v0.16.0
```

The tag must be at the current `main` head. The bump from `0.15.2` to `0.16.0` is handled by the workflow. Writing a `CHANGELOG.md` section beforehand is optional, and still preferred over the generated fallback.

## What the workflow does

1. Requires the tagged commit to be exactly the `main` head (`/compare` must return `identical`). `ahead` means the tag was never merged; `behind` means the branch moved on after tagging. Both are rejected, because the tag gets moved onto the bump commit and either case would pull commits into the release that were never tagged.
2. Sets `version` in `package.json` and `version` + `packages[""].version` in `package-lock.json` from the tag. No-op if they already match.
3. Asserts the parent each bump commit was built on. The blob sha sent to the Contents API only guards against a concurrent change to that same file, so this closes the window between the head check and the writes.
4. Re-points the tag at the bump commit, so the released tree reports the correct version — `bot/start.ts:291` reads `package.json` at runtime.
5. Builds release notes from the `CHANGELOG.md` section when present, falling back to commit subjects since the previous tag.

Release runs share a `concurrency: release` group so two tags pushed close together queue instead of interleaving their bumps.

## Why the Contents API instead of `git push`

`main` has **required signed commits** enabled, so an unsigned push from Actions would be rejected. Commits created through the Contents API are signed by GitHub, so they pass. Branch protection requires no PR review, so `GITHUB_TOKEN` with `contents: write` is sufficient.

## Deliberate trade-offs

- **Release tags end up unsigned.** A signature covers the object it was made on, so moving a tag necessarily invalidates it — no implementation can preserve one here. Annotated tags *are* preserved: if you push `git tag -a`, the tag object is recreated over the bump commit with the same message. `git tag -s` still works, but is downgraded to annotated with a `::warning::` in the log.
- **Two commits per release** (`chore: bump package.json`, `chore: sync package-lock.json`), each triggering `ci_to_main`. The Contents API writes one file per commit; that is also what makes those commits GitHub-signed, which `main` requires. Collapsing them into one needs the Git Database API, whose commits are not signed.
- **Known debt:** the Contents API cannot read or write blobs above 1 MB. `package-lock.json` is at ~264 KB. When it nears the limit this has to move to the Git Database API. Until then the script fails with an explicit message rather than an opaque parse error.

## Recovery from an interrupted run

If a run dies between the bump commits and the re-point, `main` has the bump but the tag does not. The script detects that exact state and prints the fix:

```
git fetch origin && git tag -f v0.16.0 origin/main && git push -f origin v0.16.0
```

The re-run then finds the versions already correct, skips the bumps, and publishes the release.

## Test plan

Verified locally:

- [x] `node --check` passes and `release.yaml` parses as YAML
- [x] 10 end-to-end scenarios against a mocked GitHub API: lightweight tag, annotated tag (tag object recreated), signed tag (warned + downgraded), already-bumped (no commits, tag untouched), interrupted-run recovery (explains the fix), genuinely behind, tag not merged, branch moving mid-release (aborts before the tag moves), lockfile over 1 MB, malformed tag
- [x] Notes step: the version guard rejects `v0.16.0"; system("id"); #` and `v$(id)`; escaped dots stop `0.16.0` matching a `0x16y0` heading; the real `0.15.0` section still extracts; the fallback excludes this workflow's own bump commits
- [x] The JSON transform reproduces both files byte for byte apart from the 3 version fields, so bump commits carry no formatting noise

Not verifiable outside GitHub — the live API calls. The first tagged release should be watched in the Actions log.
