### PR TITLE
ci: stop running lint and tests on tag pushes

### DIFF
--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -1,7 +1,13 @@
 name: Auto Check Lint
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    # The Release workflow moves a release tag onto the version-bump commit it
+    # creates, so a tag-triggered run aborts in checkout with "the ref does not
+    # point to the expected commit". The tagged tree is the branch tip, which
+    # this workflow already linted on push and on the pull request.
+    tags-ignore:
+      - '**'
 
 jobs: 
   Lint:

--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -2,11 +2,13 @@ name: Auto Check Lint
 on:
   pull_request:
   push:
-    # The Release workflow moves a release tag onto the version-bump commit it
-    # creates, so a tag-triggered run aborts in checkout with "the ref does not
-    # point to the expected commit". The tagged tree is the branch tip, which
-    # this workflow already linted on push and on the pull request.
-    tags-ignore:
+    # Branch pushes only. The Release workflow moves a release tag onto the
+    # version-bump commit it creates, so a tag-triggered run aborts in checkout
+    # with "the ref does not point to the expected commit"; the tagged tree is
+    # the branch tip, already linted here on push and on the pull request.
+    # Filtering branches is what excludes tags: a push trigger that defines one
+    # ref type does not run for the other.
+    branches:
       - '**'
 
 jobs: 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,7 +1,13 @@
 name: NodeJS Continuous Integration
 
-on: 
+on:
   push:
+    # The Release workflow moves a release tag onto the version-bump commit it
+    # creates, so a tag-triggered run aborts in checkout with "the ref does not
+    # point to the expected commit". The tagged tree is the branch tip, which
+    # this workflow already checked on push and on the pull request.
+    tags-ignore:
+      - '**'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -2,11 +2,13 @@ name: NodeJS Continuous Integration
 
 on:
   push:
-    # The Release workflow moves a release tag onto the version-bump commit it
-    # creates, so a tag-triggered run aborts in checkout with "the ref does not
-    # point to the expected commit". The tagged tree is the branch tip, which
-    # this workflow already checked on push and on the pull request.
-    tags-ignore:
+    # Branch pushes only. The Release workflow moves a release tag onto the
+    # version-bump commit it creates, so a tag-triggered run aborts in checkout
+    # with "the ref does not point to the expected commit"; the tagged tree is
+    # the branch tip, already checked here on push and on the pull request.
+    # Filtering branches is what excludes tags: a push trigger that defines one
+    # ref type does not run for the other.
+    branches:
       - '**'
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
## Problem

The `v0.16.0` release produced two red runs alongside the successful release:

- [Auto Check Lint #31217880953](https://github.com/lnp2pBot/bot/actions/runs/31217880953)
- [NodeJS Continuous Integration #31217881000](https://github.com/lnp2pBot/bot/actions/runs/31217881000)

Neither is a lint or test failure. Both aborted in `actions/checkout`:

```
The ref 'refs/tags/v0.16.0' does not point to the expected commit
'9e0db002ff08777ef13e917a09bc98e9f259885d'. The ref may have been
updated after the workflow was triggered.
```

Both workflows trigger on any `push`, which includes tag pushes. They started pinned to `9e0db00`, the commit the tag was pushed at. By the time they checked out, the Release workflow had already moved the tag onto the version-bump commit `191233b`, and checkout refuses the mismatch.

The tree at `9e0db00` had passed lint and CI minutes earlier as part of #901, so nothing went unverified — the runs are pure noise from re-pointing the tag.

## Fix

Restrict the `push` trigger of both workflows to branches (`branches: ['**']`). A push trigger that defines filters for one ref type does not run for the other, so filtering branches is what excludes tags.

The first attempt in this PR used `tags-ignore: ['**']` instead, which looks equivalent but is not: with only tag filters defined, branch pushes become the undefined ref type and the workflows stopped running on branch pushes altogether. Caught by review, then confirmed on this branch — pushing `2fee607` produced three `pull_request` runs and **zero** `push` runs, against eight `push` runs on the previous branch. Pushing `ebca682` with `branches: ['**']` brought them back.

`codeql-analysis.yml` needs no change: it already filters on `branches: [main]`, which is why it did not fail during the release.

## Notes

The bump commits themselves do not trigger CI at all: GitHub does not start workflow runs for events created with `GITHUB_TOKEN`. So this removes two failing runs per release and adds none.

## Test plan

- [x] Both workflows still parse, with `push` now filtered to `branches: ['**']`; `pull_request`, `workflow_dispatch` and the nightly schedule are untouched
- [x] Branch pushes still run both workflows — verified on GitHub for `ebca682`, not just by parsing the YAML, since the ref-type rule is not visible in the file
- [ ] Confirmed for real at the next release: the tag push should produce exactly one run, the Release workflow
