### PR TITLE
feat: record the payout hash before paying the buyer

### DIFF
--- a/jobs/pending_payments.ts
+++ b/jobs/pending_payments.ts
@@ -4,7 +4,12 @@ import * as messages from '../bot/messages';
 import { logger } from '../logger';
 import { Telegraf } from 'telegraf';
 import { I18nContext } from '@grammyjs/i18n';
-import { payRequest, getPaymentStatus, LndPayment } from '../ln';
+import {
+  payRequest,
+  getPaymentStatus,
+  recordPayoutIntent,
+  LndPayment,
+} from '../ln';
 import { getUserI18nContext } from '../util';
 import { CommunityContext } from '../bot/modules/community/communityContext';
 import { orderUpdated } from '../bot/modules/events/orders';
@@ -226,6 +231,10 @@ export const attemptPendingPayments = async (
       const nextRetryDelay = Math.min(exponentialDelay, maxDelay);
       pending.next_retry = new Date(Date.now() + nextRetryDelay);
 
+      // The retry may pay a NEW invoice (buyer ran /setinvoice), so the hash
+      // of THIS attempt must be recorded before the payment starts — see
+      // recordPayoutIntent for the reconciliation-window rationale.
+      await recordPayoutIntent(order, pending.payment_request);
       const payment = await payRequest({
         amount: pending.amount,
         request: pending.payment_request,

--- a/ln/index.ts
+++ b/ln/index.ts
@@ -10,6 +10,7 @@ import { resubscribeInvoices } from './resubscribe_invoices';
 import {
   payRequest,
   payToBuyer,
+  recordPayoutIntent,
   isPendingOrConfirmed,
   getPaymentStatus,
   LndPayment,
@@ -25,6 +26,7 @@ export {
   cancelHoldInvoice,
   payRequest,
   payToBuyer,
+  recordPayoutIntent,
   getInfo,
   isPendingOrConfirmed,
   getPaymentStatus,

--- a/ln/pay_request.ts
+++ b/ln/pay_request.ts
@@ -128,9 +128,10 @@ const payRequest = async ({
 // via the pending-payments job — during that window an outgoing payment
 // exists on the node with no trace in the DB, which the external
 // reconciliation monitor must treat as suspicious. Writing the hash
-// pre-flight closes that window. Best-effort by design: a failure here must
-// never block the payout — the completion path (completeOrderAsSuccess)
-// records the same hash again.
+// pre-flight narrows that window to the rare case where this write itself
+// fails. Best-effort by design: a failure here must never block the payout —
+// the completion path (completeOrderAsSuccess) records the same hash again
+// when it later runs.
 const recordPayoutIntent = async (order: IOrder, request: string) => {
   try {
     const { id } = parsePaymentRequest({ request });

--- a/ln/pay_request.ts
+++ b/ln/pay_request.ts
@@ -5,7 +5,7 @@ import {
   AuthenticatedLnd,
 } from 'lightning';
 import type { PayViaPaymentRequestResult } from 'lightning/lnd_methods/offchain/pay_via_payment_request';
-import { User, PendingPayment } from '../models';
+import { User, PendingPayment, Order } from '../models';
 import lnd from './connect';
 import { handleReputationItems, getUserI18nContext } from '../util';
 import * as messages from '../bot/messages';
@@ -122,6 +122,28 @@ const payRequest = async ({
   }
 };
 
+// Persist the payout attempt's payment hash on the order BEFORE any money
+// moves. LND can settle a payment after payRequest times out locally
+// (pathfinding_timeout), and the completion callbacks then run minutes later
+// via the pending-payments job — during that window an outgoing payment
+// exists on the node with no trace in the DB, which the external
+// reconciliation monitor must treat as suspicious. Writing the hash
+// pre-flight closes that window. Best-effort by design: a failure here must
+// never block the payout — the completion path (completeOrderAsSuccess)
+// records the same hash again.
+const recordPayoutIntent = async (order: IOrder, request: string) => {
+  try {
+    const { id } = parsePaymentRequest({ request });
+    if (!id) return;
+    await Order.updateOne({ _id: order._id }, { $set: { payout_hash: id } });
+    order.payout_hash = id;
+  } catch (error) {
+    logger.error(
+      `recordPayoutIntent: failed to record hash for order ${order._id}: ${error}`,
+    );
+  }
+};
+
 const payToBuyer = async (bot: HasTelegram, order: IOrder) => {
   try {
     // Skip if the payment is already in-flight or was confirmed
@@ -138,6 +160,7 @@ const payToBuyer = async (bot: HasTelegram, order: IOrder) => {
       );
       return;
     }
+    await recordPayoutIntent(order, order.buyer_invoice);
     const payment = await payRequest({
       request: order.buyer_invoice,
       amount: order.amount,
@@ -290,6 +313,7 @@ const isPendingOrConfirmed = async (request: string) => {
 export {
   payRequest,
   payToBuyer,
+  recordPayoutIntent,
   isPendingOrConfirmed,
   getPaymentStatus,
   LndPayment,

--- a/models/order.ts
+++ b/models/order.ts
@@ -73,7 +73,7 @@ const orderSchema = new Schema<IOrder, mongoose.Model<IOrder>>({
   bot_fee: { type: Number, min: 0 }, // bot MAX_FEE at the moment of order creation
   community_fee: { type: Number, min: 0 }, // community FEE_PERCENT at the moment of order creation
   routing_fee: { type: Number, min: 0, default: 0 },
-  payout_hash: { type: String }, // payment hash of the buyer payout (proof of payment / reconciliation)
+  payout_hash: { type: String }, // payment hash of the buyer payout attempt; written BEFORE paying (recordPayoutIntent) so reconciliation never sees an unrecorded outgoing payment, confirmed on completion
   payout_preimage: { type: String }, // preimage of the buyer payout (cryptographic proof it settled)
   hash: {
     type: String,

--- a/models/order.ts
+++ b/models/order.ts
@@ -73,7 +73,7 @@ const orderSchema = new Schema<IOrder, mongoose.Model<IOrder>>({
   bot_fee: { type: Number, min: 0 }, // bot MAX_FEE at the moment of order creation
   community_fee: { type: Number, min: 0 }, // community FEE_PERCENT at the moment of order creation
   routing_fee: { type: Number, min: 0, default: 0 },
-  payout_hash: { type: String }, // payment hash of the buyer payout attempt; written BEFORE paying (recordPayoutIntent) so reconciliation never sees an unrecorded outgoing payment, confirmed on completion
+  payout_hash: { type: String }, // payment hash of the latest recorded buyer payout attempt; written best-effort BEFORE paying (recordPayoutIntent) and confirmed on completion (completeOrderAsSuccess)
   payout_preimage: { type: String }, // preimage of the buyer payout (cryptographic proof it settled)
   hash: {
     type: String,

--- a/tests/bot/payout-intent.spec.ts
+++ b/tests/bot/payout-intent.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for recordPayoutIntent (ln/pay_request.ts).
+ *
+ * The payout attempt's payment hash must be persisted on the order BEFORE any
+ * money moves: LND can settle a payment after payRequest times out locally,
+ * and the completion callbacks (pending-payments job) then run minutes later.
+ * During that window an outgoing payment exists on the node with no trace in
+ * the DB, which the external reconciliation monitor must treat as suspicious.
+ * Writing the hash pre-flight closes that window.
+ */
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+const ORDER_ID = 'order000000000000000000001';
+const PARSED_PAYMENT_HASH = 'a'.repeat(64);
+
+describe('recordPayoutIntent', () => {
+  let sandbox: any;
+  let orderUpdateOneStub: any;
+  let parsePaymentRequestStub: any;
+  let payViaPaymentRequestStub: any;
+  let getPaymentStub: any;
+  let payRequestModule: any;
+
+  function makeFakeOrder(overrides = {}) {
+    return {
+      _id: ORDER_ID,
+      buyer_id: 'buyer00000000000000000001',
+      seller_id: 'seller0000000000000000001',
+      buyer_invoice: 'lnbc_buyer_invoice',
+      amount: 1000,
+      status: 'PAID_HOLD_INVOICE',
+      payout_hash: null,
+      payout_preimage: null,
+      save: sandbox.stub().resolves(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    process.env.MAX_ROUTING_FEE = '0.003';
+
+    orderUpdateOneStub = sandbox.stub().resolves({});
+    parsePaymentRequestStub = sandbox
+      .stub()
+      .returns({ id: PARSED_PAYMENT_HASH, is_expired: false });
+    payViaPaymentRequestStub = sandbox.stub().rejects(new Error('no route'));
+    getPaymentStub = sandbox
+      .stub()
+      .resolves({ is_confirmed: false, is_pending: false });
+
+    payRequestModule = proxyquire('../../ln/pay_request', {
+      lightning: {
+        payViaPaymentRequest: payViaPaymentRequestStub,
+        getPayment: getPaymentStub,
+        deleteForwardingReputations: sandbox.stub().resolves(),
+        '@noCallThru': true,
+      },
+      './connect': { default: {}, '@noCallThru': true },
+      invoices: {
+        parsePaymentRequest: parsePaymentRequestStub,
+        '@noCallThru': true,
+      },
+      '../models': {
+        Order: { updateOne: orderUpdateOneStub },
+        User: { findOne: sandbox.stub().resolves({ _id: 'u1', tg_id: 't1' }) },
+        PendingPayment: function (this: any) {
+          this.save = sandbox.stub().resolves();
+        },
+        '@noCallThru': true,
+      },
+      '../util': {
+        handleReputationItems: sandbox.stub().resolves(),
+        getUserI18nContext: sandbox.stub().resolves({ t: (k: string) => k }),
+        '@noCallThru': true,
+      },
+      '../bot/messages': {
+        invoicePaymentFailedMessage: sandbox.stub().resolves(),
+        toAdminChannelOrderErrorMessage: sandbox.stub().resolves(),
+        '@noCallThru': true,
+      },
+      '../bot/modules/events/orders': {
+        orderUpdated: sandbox.stub(),
+        '@noCallThru': true,
+      },
+      '../logger': {
+        logger: {
+          info: sandbox.stub(),
+          error: sandbox.stub(),
+          warning: sandbox.stub(),
+          debug: sandbox.stub(),
+        },
+        logTimeout: sandbox.stub(),
+        logOperationDuration: sandbox.stub(),
+        '@noCallThru': true,
+      },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('persists the parsed payment hash on the order before paying', async () => {
+    const order = makeFakeOrder();
+
+    await payRequestModule.recordPayoutIntent(order, 'lnbc_new_invoice');
+
+    sinon.assert.calledWithMatch(
+      orderUpdateOneStub,
+      { _id: ORDER_ID },
+      { $set: { payout_hash: PARSED_PAYMENT_HASH } },
+    );
+    expect(order.payout_hash).to.equal(PARSED_PAYMENT_HASH);
+  });
+
+  it('never throws when the invoice cannot be parsed', async () => {
+    parsePaymentRequestStub.throws(new Error('invalid invoice'));
+    const order = makeFakeOrder();
+
+    await payRequestModule.recordPayoutIntent(order, 'garbage');
+
+    sinon.assert.notCalled(orderUpdateOneStub);
+    expect(order.payout_hash).to.equal(null);
+  });
+
+  it('never blocks the payout when the DB write fails', async () => {
+    orderUpdateOneStub.rejects(new Error('mongo down'));
+    const order = makeFakeOrder();
+
+    // Must resolve without throwing: this write is bookkeeping, the
+    // completion path records the hash again.
+    await payRequestModule.recordPayoutIntent(order, 'lnbc_new_invoice');
+  });
+
+  it('payToBuyer records the payout intent before any payment attempt', async () => {
+    const order = makeFakeOrder();
+
+    await payRequestModule.payToBuyer({ telegram: {} }, order);
+
+    // The intent write must land BEFORE the LND payment call.
+    sinon.assert.calledWithMatch(
+      orderUpdateOneStub,
+      { _id: ORDER_ID },
+      { $set: { payout_hash: PARSED_PAYMENT_HASH } },
+    );
+    sinon.assert.callOrder(orderUpdateOneStub, payViaPaymentRequestStub);
+  });
+});
+
+export {};

--- a/tests/bot/pending-payments.spec.ts
+++ b/tests/bot/pending-payments.spec.ts
@@ -76,6 +76,7 @@ describe('attemptPendingPayments healing branches', () => {
   let sandbox: any;
   let getPaymentStatusStub: any;
   let payRequestStub: any;
+  let recordPayoutIntentStub: any;
   let orderFindOneStub: any;
   let userFindOneStub: any;
   let pendingFindStub: any;
@@ -95,6 +96,7 @@ describe('attemptPendingPayments healing branches', () => {
 
     getPaymentStatusStub = sandbox.stub();
     payRequestStub = sandbox.stub();
+    recordPayoutIntentStub = sandbox.stub().resolves();
     orderFindOneStub = sandbox.stub();
     userFindOneStub = sandbox.stub();
     pendingFindStub = sandbox.stub();
@@ -134,6 +136,7 @@ describe('attemptPendingPayments healing branches', () => {
       '../ln': {
         payRequest: payRequestStub,
         getPaymentStatus: getPaymentStatusStub,
+        recordPayoutIntent: recordPayoutIntentStub,
         '@global': true,
         '@noCallThru': true,
       },
@@ -304,6 +307,35 @@ describe('attemptPendingPayments healing branches', () => {
       expect(toBuyerStub.calledOnce).to.equal(true, 'buyer must be notified');
       expect(rateUserStub.calledOnce).to.equal(true, 'rating must be sent');
       expect(payRequestStub.called).to.equal(false);
+    });
+  });
+
+  // ── Payout intent: the attempt's hash must be recorded BEFORE paying ───────────
+
+  describe('payment attempt', () => {
+    it('records the payout intent before attempting the payment', async () => {
+      const order = makeFakeOrder();
+      const pending = makeFakePending();
+      const buyer = makeFakeUser(BUYER_ID);
+
+      pendingFindStub.onFirstCall().resolves([pending]);
+      pendingFindStub.onSecondCall().resolves([]);
+      orderFindOneStub.resolves(order);
+      userFindOneStub.withArgs({ _id: BUYER_ID }).resolves(buyer);
+      getPaymentStatusStub.resolves({ is_confirmed: false, is_pending: false });
+      payRequestStub.resolves({ error: 'TIMEOUT', message: 'timed out' });
+
+      await job.attemptPendingPayments(fakeBot);
+
+      // The hash of the invoice about to be paid must be persisted before the
+      // payment starts, so a settlement that outlives the local timeout is
+      // never an unrecorded outgoing payment.
+      sinon.assert.calledWith(
+        recordPayoutIntentStub,
+        order,
+        pending.payment_request,
+      );
+      sinon.assert.callOrder(recordPayoutIntentStub, payRequestStub);
     });
   });
 

--- a/tests/jobs/pending_payments.spec.ts
+++ b/tests/jobs/pending_payments.spec.ts
@@ -37,6 +37,7 @@ describe('attemptPendingPayments (issue #864)', () => {
     payment: any;
   }) {
     const payRequest = sinon.stub().resolves(payment);
+    const recordPayoutIntent = sinon.stub().resolves();
     const getPaymentStatus = sinon.stub().resolves(notPaidStatus);
     const orderUpdated = sinon.stub();
 
@@ -117,7 +118,7 @@ describe('attemptPendingPayments (issue #864)', () => {
         '../models': models,
         '../bot/messages': messages,
         '../logger': loggerStub(),
-        '../ln': { payRequest, getPaymentStatus },
+        '../ln': { payRequest, getPaymentStatus, recordPayoutIntent },
         '../util': utilStub(),
         '../bot/modules/events/orders': { orderUpdated },
         '../util/completeOrder': { completeOrderAsSuccess, healConfirmedOrder },

--- a/tests/ln/pay_request.spec.ts
+++ b/tests/ln/pay_request.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Tests for recordPayoutIntent (ln/pay_request.ts).
+ * Tests for recordPayoutIntent and the payout-intent wiring in payToBuyer
+ * (ln/pay_request.ts).
  *
  * The payout attempt's payment hash must be persisted on the order BEFORE any
  * money moves: LND can settle a payment after payRequest times out locally,


### PR DESCRIPTION
## Problem

The reconciliation monitor (lnp2pbot-monitor) raised three false CRITICAL alerts on 2026-08-08 for legitimate buyer payouts (204k, 321k, 9.7k sats). Root cause is a write-ordering gap in the bot:

1. `payToBuyer` / the pending-payments job call `payRequest` and only write `order.payout_hash` **after** `payViaPaymentRequest` resolves.
2. With `pathfinding_timeout` (60s default), the local call can time out while the payment is still in flight — **and LND settles it afterwards**.
3. The bot only records the payout when the pending-payments job later heals the confirmed payment — **minutes** after the money actually left the node.

During that window an outgoing payment exists on the node with no trace in the DB — exactly the signature of a drain, so the monitor must alert on it. One of the three alerts also surfaced an order (`CLOSED`, no `payout_hash`, no `buyer_invoice_paid`) whose payout completion was never recorded at all.

## Fix

`recordPayoutIntent(order, request)`: parse the invoice about to be paid and persist its payment hash on the order **before any money moves**. Called in both payout paths:

- `payToBuyer` (direct payout)
- pending-payments retry job (which may pay a **new** invoice after `/setinvoice` — the hash of *this* attempt is recorded)

Design notes:
- **Best-effort**: a parse or DB failure logs and continues — this bookkeeping write must never block a payout. The completion path (`completeOrderAsSuccess`) still records the same hash idempotently.
- `payout_hash` semantics shift from "proof of completed payout" to "hash of the (latest) payout attempt, confirmed on completion". Nothing in the bot reads it; it exists for reconciliation, which verifies amounts and the hold invoice independently.
- Community withdrawals already record their hash at creation (`bot/modules/community/scenes.ts`) — no change.
- No payment, amount, or security logic touched.

## Test plan

- [x] New `tests/bot/payout-intent.spec.ts`: hash persisted with the parsed id; parse errors swallowed; DB errors never block the payout; `payToBuyer` writes the intent **before** `payViaPaymentRequest` (call-order assertion)
- [x] `tests/bot/pending-payments.spec.ts`: the retry job records the intent before `payRequest` (call-order assertion)
- [x] Full suite: 219 passing, eslint + prettier clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Payout payment requests are now recorded before payment processing begins, improving payment tracking and reconciliation.
  - Successful payouts can be matched to their original payment request for more reliable status visibility.

- **Bug Fixes**
  - Payouts continue processing even if recording the payment intent fails.
  - Invalid payment requests no longer disrupt payout processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->