### PR TITLE
feat: add video tutorial links to the sunset message

### DIFF
--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -607,6 +607,8 @@ sunset: |
   If you want to use Mostro: https://mostro.network
   If you want to run your own Mostro node: https://mostro.community/
 
+  🎥 Video tutorial: https://www.youtube.com/watch?v=Lnyjgecfd_w
+
 # START modules/community
 community_admin: |
   <strong>Community Admin Mode</strong>

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -602,6 +602,8 @@ sunset: |
   Si quieres usar Mostro: https://mostro.network
   Si quieres correr tu propio nodo Mostro: https://mostro.community/
 
+  🎥 Video tutorial: https://www.youtube.com/watch?v=lbenPWNlykk
+
 # START modules/community
 community_admin: |
   <strong>Community Admin Mode</strong>

--- a/tests/bot/sunset.spec.ts
+++ b/tests/bot/sunset.spec.ts
@@ -11,6 +11,8 @@ const SPANISH_ANNOUNCEMENT =
   'https://x.com/negrunch/status/2086896990256799795';
 const ENGLISH_ANNOUNCEMENT =
   'https://x.com/negrunch/status/2086899005355704703';
+const SPANISH_VIDEO_TUTORIAL = 'https://www.youtube.com/watch?v=lbenPWNlykk';
+const ENGLISH_VIDEO_TUTORIAL = 'https://www.youtube.com/watch?v=Lnyjgecfd_w';
 
 const makeCtx = (from: any) => {
   const locales: string[] = [];
@@ -90,6 +92,7 @@ describe('sunset mode', () => {
       const es = readLocale('es');
       expect(es).to.include('sunset:');
       expect(es).to.include(SPANISH_ANNOUNCEMENT);
+      expect(es).to.include(SPANISH_VIDEO_TUTORIAL);
       expect(es).to.include('https://mostro.network');
       expect(es).to.include('https://mostro.community');
     });
@@ -98,6 +101,7 @@ describe('sunset mode', () => {
       const en = readLocale('en');
       expect(en).to.include('sunset:');
       expect(en).to.include(ENGLISH_ANNOUNCEMENT);
+      expect(en).to.include(ENGLISH_VIDEO_TUTORIAL);
       expect(en).to.include('https://mostro.network');
       expect(en).to.include('https://mostro.community');
     });


### PR DESCRIPTION
## Summary

Adds a video tutorial link to the sunset notice introduced in #911:

- Spanish message: https://www.youtube.com/watch?v=lbenPWNlykk
- English message (used by every other locale via i18n fallback): https://www.youtube.com/watch?v=Lnyjgecfd_w

## Test plan

- [x] `npm test` — 225 passing; the locale specs in `tests/bot/sunset.spec.ts` now also assert the tutorial links per language
- [x] `npm run lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tutorial video links to the sunset messages in English and Spanish.
  * Users can access Mostro guidance directly from these messages.

* **Tests**
  * Updated message checks to verify that the tutorial links are included in both languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->