### PR TITLE
fix: keep the taker message deliverable when MarkdownV2 parsing fails

### DIFF
--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -555,6 +555,28 @@ const onGoingTakeBuyMessage = async (
   }
 };
 
+// Sends a MarkdownV2 message, retrying once as plain text if Telegram rejects
+// the formatting. A single unescaped reserved character in a translation makes
+// sendMessage throw, and callers that send follow-up messages (e.g. the order
+// action buttons) would never reach them. Escaping locales fixes the known
+// cases; this keeps the message deliverable when a new one slips through.
+// The failing locale is logged so the offending translation can be corrected.
+const sendMarkdownV2WithPlainFallback = async (
+  bot: HasTelegram,
+  tgId: string,
+  text: string,
+  locale: string,
+) => {
+  try {
+    await bot.telegram.sendMessage(tgId, text, { parse_mode: 'MarkdownV2' });
+  } catch (error) {
+    logger.warning(
+      `MarkdownV2 send failed for locale "${locale}", retrying as plain text: ${error}`,
+    );
+    await bot.telegram.sendMessage(tgId, text);
+  }
+};
+
 const beginTakeSellMessage = async (
   ctx: MainContext,
   bot: HasTelegram,
@@ -570,10 +592,11 @@ const beginTakeSellMessage = async (
     let expirationTime = time.hours + ' ' + ctx.i18n.t('hours');
     expirationTime +=
       time.minutes > 0 ? ' ' + time.minutes + ' ' + ctx.i18n.t('minutes') : '';
-    await bot.telegram.sendMessage(
+    await sendMarkdownV2WithPlainFallback(
+      bot,
       buyer.tg_id,
       ctx.i18n.t('you_took_someone_order', { expirationTime }),
-      { parse_mode: 'MarkdownV2' },
+      ctx.i18n.locale(),
     );
     await bot.telegram.sendMessage(buyer.tg_id, order._id, {
       reply_markup: {

--- a/bot/messages.ts
+++ b/bot/messages.ts
@@ -555,12 +555,25 @@ const onGoingTakeBuyMessage = async (
   }
 };
 
-// Sends a MarkdownV2 message, retrying once as plain text if Telegram rejects
-// the formatting. A single unescaped reserved character in a translation makes
-// sendMessage throw, and callers that send follow-up messages (e.g. the order
-// action buttons) would never reach them. Escaping locales fixes the known
-// cases; this keeps the message deliverable when a new one slips through.
-// The failing locale is logged so the offending translation can be corrected.
+// Telegram rejects a MarkdownV2 message with 400 "can't parse entities" when a
+// translation contains an unescaped reserved character.
+const isMarkdownParseError = (error: unknown) =>
+  error instanceof TelegramError &&
+  error.response.error_code === 400 &&
+  /can't parse entities/i.test(error.response.description ?? '');
+
+// MarkdownV2 escapes (`\.`, `\(`, …) are meaningless once parse_mode is
+// dropped, so strip them before falling back or the reader sees the backslashes.
+const unescapeMarkdownV2 = (text: string) => text.replace(/\\(.)/g, '$1');
+
+// Sends a MarkdownV2 message, retrying once as plain text when Telegram rejects
+// the formatting. A single unescaped reserved character makes sendMessage throw,
+// and callers that send follow-up messages (e.g. the order action buttons) never
+// reach them. Escaping locales fixes the known characters; this keeps the
+// message deliverable when a new one slips through. Errors that aren't parse
+// failures (rate limits, blocked bot, network) are re-thrown untouched so we
+// don't duplicate a message that may already have been delivered.
+// The failing locale is logged so the translation can be corrected.
 const sendMarkdownV2WithPlainFallback = async (
   bot: HasTelegram,
   tgId: string,
@@ -570,10 +583,11 @@ const sendMarkdownV2WithPlainFallback = async (
   try {
     await bot.telegram.sendMessage(tgId, text, { parse_mode: 'MarkdownV2' });
   } catch (error) {
+    if (!isMarkdownParseError(error)) throw error;
     logger.warning(
       `MarkdownV2 send failed for locale "${locale}", retrying as plain text: ${error}`,
     );
-    await bot.telegram.sendMessage(tgId, text);
+    await bot.telegram.sendMessage(tgId, unescapeMarkdownV2(text));
   }
 };
 

--- a/tests/bot/markdownV2Fallback.spec.ts
+++ b/tests/bot/markdownV2Fallback.spec.ts
@@ -3,6 +3,14 @@ export {};
 const { expect } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
+const { TelegramError } = require('telegraf');
+
+// Builds the error Telegram returns when a translation breaks MarkdownV2.
+const parseError = () =>
+  new TelegramError({
+    error_code: 400,
+    description: "Bad Request: can't parse entities: character '.' is reserved",
+  });
 
 // Issue #882: a single unescaped MarkdownV2 reserved character in a translation
 // makes Telegram reject the "you took someone's order" message. Because the
@@ -36,18 +44,21 @@ const { beginTakeSellMessage } = proxyquire('../../bot/messages', {
 const BUYER = { tg_id: '111', lang: 'fa' };
 const ORDER = { _id: 'order123' };
 
+// Mirrors the real translation shape: MarkdownV2 escapes reserved characters
+// with a backslash (the locales carry `\\.` which compiles to `\.` at runtime).
+const ESCAPED_TEXT = 'no risk of freezing funds\\. Press to continue \\(now\\)';
+const PLAIN_TEXT = 'no risk of freezing funds. Press to continue (now)';
+
 // ctx whose locale is Persian, mirroring the reported scenario.
 const makeCtx = () => ({
-  i18n: { t: (k: string) => k, locale: () => 'fa' },
+  i18n: { t: () => ESCAPED_TEXT, locale: () => 'fa' },
 });
 
 describe('MarkdownV2 send falls back to plain text (#882)', () => {
   it('retries as plain text and still delivers the action buttons', async () => {
     const sendMessage = sinon.stub();
     // First call is the MarkdownV2 one: Telegram rejects the formatting.
-    sendMessage
-      .onFirstCall()
-      .rejects(new Error("Bad Request: can't parse entities"));
+    sendMessage.onFirstCall().rejects(parseError());
     sendMessage.resolves();
     const bot: any = { telegram: { sendMessage } };
 
@@ -56,13 +67,16 @@ describe('MarkdownV2 send falls back to plain text (#882)', () => {
     // 1) MarkdownV2 attempt, 2) plain-text retry, 3) buttons
     expect(sendMessage.callCount).to.equal(3);
 
-    // The retry carries the same text without parse_mode
+    // The retry drops parse_mode and strips the now-meaningless MarkdownV2
+    // escapes, so the reader doesn't see stray backslashes.
     const [firstArgs, retryArgs] = [
       sendMessage.getCall(0).args,
       sendMessage.getCall(1).args,
     ];
     expect(firstArgs[2]).to.deep.equal({ parse_mode: 'MarkdownV2' });
-    expect(retryArgs[1]).to.equal(firstArgs[1]);
+    expect(firstArgs[1]).to.equal(ESCAPED_TEXT);
+    expect(retryArgs[1]).to.equal(PLAIN_TEXT);
+    expect(retryArgs[1]).to.not.include('\\');
     expect(retryArgs[2]).to.equal(undefined);
 
     // The taker still receives the Continue/Cancel buttons — without this the
@@ -74,6 +88,19 @@ describe('MarkdownV2 send falls back to plain text (#882)', () => {
       'addInvoiceBtn',
       'cancelAddInvoiceBtn',
     ]);
+  });
+
+  it('does not retry on non-formatting errors (no duplicate sends)', async () => {
+    // A network/rate-limit failure may mean the message was already delivered,
+    // so retrying it would send the risk warning twice.
+    const sendMessage = sinon.stub().rejects(new Error('socket hang up'));
+    const bot: any = { telegram: { sendMessage } };
+
+    await beginTakeSellMessage(makeCtx() as any, bot, BUYER as any, ORDER);
+
+    // Only the original attempt: no plain-text retry, and the outer handler
+    // logs the error as it did before.
+    expect(sendMessage.callCount).to.equal(1);
   });
 
   it('keeps MarkdownV2 formatting when the locale is safe', async () => {

--- a/tests/bot/markdownV2Fallback.spec.ts
+++ b/tests/bot/markdownV2Fallback.spec.ts
@@ -1,0 +1,91 @@
+export {};
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+// Issue #882: a single unescaped MarkdownV2 reserved character in a translation
+// makes Telegram reject the "you took someone's order" message. Because the
+// follow-up message carrying the Continue/Cancel buttons is sent right after,
+// losing the first send also left the taker without any way to act on the order.
+// The send now falls back to plain text so both messages get through.
+
+const utilMock = {
+  secondsToTime: () => ({ hours: 23, minutes: 0 }),
+  holdInvoiceExpirationInSecs: () => ({
+    expirationTimeInSecs: 86400,
+    safetyWindowInSecs: 3600,
+  }),
+  getCurrency: () => ({ symbol_native: '$' }),
+  numberFormat: (_c: string, n: number) => String(n),
+  getDetailedOrder: sinon.stub().returns(''),
+  getOrderChannel: sinon.stub().resolves(''),
+  sanitizeMD: (x: string) => x,
+  getEmojiRate: () => '',
+  decimalRound: (x: number) => x,
+  getUserAge: () => 0,
+  getStars: () => '',
+  generateQRWithImage: sinon.stub().resolves(Buffer.from('')),
+};
+
+const { beginTakeSellMessage } = proxyquire('../../bot/messages', {
+  '../util': utilMock,
+  '../util/imageCache': { imageCache: { convertImageToBase64: sinon.stub() } },
+});
+
+const BUYER = { tg_id: '111', lang: 'fa' };
+const ORDER = { _id: 'order123' };
+
+// ctx whose locale is Persian, mirroring the reported scenario.
+const makeCtx = () => ({
+  i18n: { t: (k: string) => k, locale: () => 'fa' },
+});
+
+describe('MarkdownV2 send falls back to plain text (#882)', () => {
+  it('retries as plain text and still delivers the action buttons', async () => {
+    const sendMessage = sinon.stub();
+    // First call is the MarkdownV2 one: Telegram rejects the formatting.
+    sendMessage
+      .onFirstCall()
+      .rejects(new Error("Bad Request: can't parse entities"));
+    sendMessage.resolves();
+    const bot: any = { telegram: { sendMessage } };
+
+    await beginTakeSellMessage(makeCtx() as any, bot, BUYER as any, ORDER);
+
+    // 1) MarkdownV2 attempt, 2) plain-text retry, 3) buttons
+    expect(sendMessage.callCount).to.equal(3);
+
+    // The retry carries the same text without parse_mode
+    const [firstArgs, retryArgs] = [
+      sendMessage.getCall(0).args,
+      sendMessage.getCall(1).args,
+    ];
+    expect(firstArgs[2]).to.deep.equal({ parse_mode: 'MarkdownV2' });
+    expect(retryArgs[1]).to.equal(firstArgs[1]);
+    expect(retryArgs[2]).to.equal(undefined);
+
+    // The taker still receives the Continue/Cancel buttons — without this the
+    // order could not be advanced or cancelled at all.
+    const buttonsCall = sendMessage.getCall(2).args;
+    expect(buttonsCall[1]).to.equal(ORDER._id);
+    const keyboard = buttonsCall[2].reply_markup.inline_keyboard[0];
+    expect(keyboard.map((b: any) => b.callback_data)).to.deep.equal([
+      'addInvoiceBtn',
+      'cancelAddInvoiceBtn',
+    ]);
+  });
+
+  it('keeps MarkdownV2 formatting when the locale is safe', async () => {
+    const sendMessage = sinon.stub().resolves();
+    const bot: any = { telegram: { sendMessage } };
+
+    await beginTakeSellMessage(makeCtx() as any, bot, BUYER as any, ORDER);
+
+    // No retry needed: the MarkdownV2 send plus the buttons.
+    expect(sendMessage.callCount).to.equal(2);
+    expect(sendMessage.getCall(0).args[2]).to.deep.equal({
+      parse_mode: 'MarkdownV2',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #882.

When a translation contains an unescaped MarkdownV2 reserved character, Telegram rejects the `you_took_someone_order` send. Because `beginTakeSellMessage` sends the order's **Continue/Cancel buttons right after**, the throw was caught by the outer handler and **the buttons were never sent** — so the taker was left not only without the confirmation text, but **without any way to advance or cancel the order** until it expired. That's the part worth highlighting: the impact is a stuck trade, not just a missing message.

## Approach

The send now goes through a small helper that retries once **without** `parse_mode` when Telegram returns 400 `can't parse entities`, so the flow continues and the buttons are delivered.

- **Narrowed to parse errors.** Any other failure (429, 403, network) is re-thrown untouched — retrying those could duplicate a message that was already delivered, ignore `retry_after`, or repeat a call guaranteed to fail. This follows the existing `error instanceof TelegramError && error.response.error_code === …` pattern in this file.
- **Escapes stripped on the retry.** The locales carry `\.` / `\(` escapes that are meaningless without `parse_mode`; sending verbatim would show stray backslashes in the funds-risk warning.
- **The failing locale is logged**, so the offending translation can be corrected at the source.

This complements #872 (escaping the Farsi locale) rather than replacing it: escaping fixes the known characters, this keeps the flow usable if a new one slips through.

## Note (not addressed here)

`onGoingTakeSellMessage` has the same shape — a MarkdownV2 send sitting before the seller's "your order was taken" notification. It's latent today (`/fiatsent` is safe in all ten locales), so I left it out to keep this scoped to the reported bug. Happy to apply the same helper there if you'd prefer.

## Local validation

```
npx tsc            ✅
npm run lint       ✅
npm run format     ✅
npm test           ✅ 217 passing
```

Tests cover the plain-text retry, that **the action buttons are still delivered**, that non-formatting errors are not retried, and that MarkdownV2 is preserved when the locale is safe. Verified the regression test fails without the fix (only 1 send happens; the buttons never go out).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message delivery when Markdown formatting errors occur.
  * Automatically retries affected messages as plain text, allowing follow-up action buttons to remain available.
  * Non-formatting errors continue to be handled normally.

* **Tests**
  * Added coverage for formatting failures, non-formatting errors, and locales where Markdown formatting succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->