### PR TITLE
chore(deps): bump invoices from 2.0.6 to 6.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "canvas": "^3.0.0",
         "crypto": "^1.0.1",
         "dotenv": "^10.0.0",
-        "invoices": "2.0.6",
+        "invoices": "6.0.5",
         "lightning": "11.1.0",
         "mongoose": "^8.24.0",
         "node-schedule": "^2.0.0",
@@ -1238,6 +1238,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -1267,13 +1268,10 @@
       "dev": true
     },
     "node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1332,17 +1330,17 @@
       "license": "MIT"
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.0.1.tgz",
-      "integrity": "sha512-x/7D4jDj/MMkmO6t3p2CSDXTqpwZ/jRsRiJDmaiXabrR9XRo7jwby8HRn7EyK1h24rKFFI7vI0ay4czl6bDOZQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
+      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
+      "license": "MIT",
       "dependencies": {
+        "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
-        "bip174": "^2.0.1",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.1.0",
+        "bip174": "^2.1.1",
+        "bs58check": "^3.0.1",
         "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2",
-        "wif": "^2.0.1"
+        "varuint-bitcoin": "^1.1.2"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -1408,19 +1406,21 @@
       "license": "MIT"
     },
     "node_modules/bolt07": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/bolt07/-/bolt07-1.8.1.tgz",
-      "integrity": "sha512-vgh796VOdJBunZZZX0YuW1DmkS9SbW93rCLPOmWPsAHS/mStEs4+5d0KM1bYX6QBHshY9ecg4kgJaB18jrZsIA==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/bolt07/-/bolt07-1.9.5.tgz",
+      "integrity": "sha512-nV5q5bAv+dLQAAUYgbVh4ilxmG9XQBLpzB0yBNt9AhkHVf3+dNz5kEqMViK6AuTntY87k2ahBwkJng2ocbFUSA==",
+      "license": "MIT",
       "dependencies": {
-        "bn.js": "5.2.0"
+        "bn.js": "5.2.3"
       }
     },
     "node_modules/bolt09": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/bolt09/-/bolt09-0.2.3.tgz",
-      "integrity": "sha512-xEt5GE6pXB8wMIWHAoyF28k0Yt2rFqIou1LCyIeNadAOQhu/F7GTjZwreFwLl07YYkhOH23avewRt5PD8JnKKg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bolt09/-/bolt09-2.2.0.tgz",
+      "integrity": "sha512-MzpiDQE4QavQTh5EqNv+Tmv+yoZMHys3j4OU3iiGO50IAu7FbVWmj1sipHIT+lvCKG6ROBFIJezND2vE3io75Q==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=18"
       }
     },
     "node_modules/brace-expansion": {
@@ -1452,21 +1452,22 @@
       "dev": true
     },
     "node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
-        "base-x": "^3.0.2"
+        "base-x": "^4.0.0"
       }
     },
     "node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
+      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "license": "MIT",
       "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^5.0.0"
       }
     },
     "node_modules/bson": {
@@ -1567,6 +1568,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -1598,6 +1600,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1721,19 +1724,6 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
-      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -1868,18 +1858,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",
@@ -2045,6 +2023,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3130,6 +3109,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -3437,6 +3417,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -3480,19 +3461,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/hasown": {
@@ -3665,19 +3633,20 @@
       }
     },
     "node_modules/invoices": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/invoices/-/invoices-2.0.6.tgz",
-      "integrity": "sha512-adGV6WmSItMWzuZXmgR2sbaiLKXMg4YTybNgmSc+TsNDCVgTFluJFUWaihyn1ewK483z6/vNZ9VMP2tYw5tMug==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/invoices/-/invoices-6.0.5.tgz",
+      "integrity": "sha512-J1aQ6cYkyUMAw84uWNEa/8htRBGqXFP+XQBxUysvAf8TO/Zuz9f5G1NAgwsJ75Y4C+FDoB5cXvMTSm54piHtaw==",
+      "license": "MIT",
       "dependencies": {
         "bech32": "2.0.0",
-        "bitcoinjs-lib": "6.0.1",
-        "bn.js": "5.2.0",
-        "bolt07": "1.8.1",
-        "bolt09": "0.2.3",
-        "tiny-secp256k1": "2.2.1"
+        "bitcoinjs-lib": "6.1.7",
+        "bn.js": "5.2.5",
+        "bolt07": "1.9.5",
+        "bolt09": "2.2.0",
+        "tiny-secp256k1": "2.2.4"
       },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=22"
       }
     },
     "node_modules/ip-address": {
@@ -3764,6 +3733,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3984,6 +3954,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -4027,7 +3998,8 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4185,66 +4157,6 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
-    "node_modules/lightning/node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "license": "MIT"
-    },
-    "node_modules/lightning/node_modules/bitcoinjs-lib": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
-      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/lightning/node_modules/bolt07": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/bolt07/-/bolt07-1.9.5.tgz",
-      "integrity": "sha512-nV5q5bAv+dLQAAUYgbVh4ilxmG9XQBLpzB0yBNt9AhkHVf3+dNz5kEqMViK6AuTntY87k2ahBwkJng2ocbFUSA==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "5.2.3"
-      }
-    },
-    "node_modules/lightning/node_modules/bolt09": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bolt09/-/bolt09-2.2.0.tgz",
-      "integrity": "sha512-MzpiDQE4QavQTh5EqNv+Tmv+yoZMHys3j4OU3iiGO50IAu7FbVWmj1sipHIT+lvCKG6ROBFIJezND2vE3io75Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/lightning/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
-      }
-    },
-    "node_modules/lightning/node_modules/bs58check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
-      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
-      }
-    },
     "node_modules/lightning/node_modules/invoices": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/invoices/-/invoices-5.0.2.tgz",
@@ -4260,18 +4172,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/lightning/node_modules/tiny-secp256k1": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.4.tgz",
-      "integrity": "sha512-FoDTcToPqZE454Q04hH9o2EhxWsm7pOSpicyHkgTwKhdKWdsTUuqfP5MLq3g+VjAtl2vSx6JpXGdwA2qpYkI0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "uint8array-tools": "0.0.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/lightning/node_modules/type-fest": {
@@ -4402,16 +4302,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/media-typer": {
@@ -5344,6 +5234,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5523,48 +5414,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/psbt/node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "license": "MIT"
-    },
-    "node_modules/psbt/node_modules/bitcoinjs-lib": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
-      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/psbt/node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
-      }
-    },
-    "node_modules/psbt/node_modules/bs58check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
-      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
       }
     },
     "node_modules/pstree.remy": {
@@ -5956,15 +5805,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6159,6 +5999,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -6192,26 +6033,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.0"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6682,28 +6503,15 @@
       "dev": true
     },
     "node_modules/tiny-secp256k1": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz",
-      "integrity": "sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.4.tgz",
+      "integrity": "sha512-FoDTcToPqZE454Q04hH9o2EhxWsm7pOSpicyHkgTwKhdKWdsTUuqfP5MLq3g+VjAtl2vSx6JpXGdwA2qpYkI0Q==",
+      "license": "MIT",
       "dependencies": {
         "uint8array-tools": "0.0.7"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/to-buffer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
-      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/to-regex-range": {
@@ -6860,6 +6668,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -7159,6 +6968,7 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -7174,14 +6984,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
-      "dependencies": {
-        "bs58check": "<3.0.0"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "canvas": "^3.0.0",
     "crypto": "^1.0.1",
     "dotenv": "^10.0.0",
-    "invoices": "2.0.6",
+    "invoices": "6.0.5",
     "lightning": "11.1.0",
     "mongoose": "^8.24.0",
     "node-schedule": "^2.0.0",


### PR DESCRIPTION
## Summary
- Bump `invoices` from `2.0.6` to `6.0.5`.

**Note:** `invoices@6.0.0+` requires Node.js >= 22. This PR depends on #915 (bump Node engine to 22) and will fail CI until that one is merged into `main`.

## Why
`invoices@6.0.0+` includes a correctness/security fix in `bolt11/request_details.js`: when a BOLT11 payment request had multiple `id` tagged fields, the parser kept overwriting `sum.id` with the last one found instead of the first. We rely on `invoice.id` (the payment request hash) as the source of truth for payment tracking:
- `bot/validations.ts` validates `invoice.id` exists before accepting an invoice
- `ln/pay_request.ts` stores it as `order.payout_hash`
- `ln/resubscribe_invoices.ts` and `ln/subscribe_invoice.ts` look up orders by `hash: invoice.id`

A malformed or adversarial invoice with a duplicated `id` tag could previously cause the bot to track the wrong payment hash. This fix makes that path correct.

## Changes
- `package.json`: `invoices` `2.0.6` → `6.0.5`
- `package-lock.json` updated accordingly

## Breaking changes reviewed
Went through the full `invoices` CHANGELOG from `2.0.6` to `6.0.5`. All breaking changes are Node.js engine bumps (16 → 18 → 20 → 22), already covered by #915. No other breaking change applies to this codebase — we only use `parsePaymentRequest` in production code (`createUnsignedRequest`/`createSignedRequest` are only used in tests), and none of the affected fields (CLTV delta default, P2TR fallback addresses, signet support) are used here.

## Testing
- `npm install` — installs cleanly
- `npx tsc --noEmit` — no type errors
- `npm run lint` — no lint errors
- `npm test` — 233 passing, 4 pre-existing failures unrelated to this change (missing `getCommunityByIdentifier`, from unrelated in-progress work)
- Manually tested the `/sell` and `/buy` flows end-to-end