### PR TITLE
feat: allow the bot to start without a database in sunset mode

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -5,9 +5,10 @@ LND_MACAROON_BASE64=''
 LND_GRPC_HOST='127.0.0.1:10009'
 BOT_TOKEN=''
 
-# When 'true' the bot stops trading: it never connects to the LN node,
-# schedules no jobs, and replies to every message with a
-# service-discontinued notice pointing users to Mostro
+# When 'true' the bot stops trading: it never connects to the LN node nor to
+# MongoDB (the DB_* / MONGO_URI variables become optional), schedules no jobs,
+# and replies to every message with a service-discontinued notice pointing
+# users to Mostro
 SUNSET_MODE='false'
 
 # The max fee amount that the Bot will charge to the seller, 0.002 = 0.2%

--- a/app.ts
+++ b/app.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import dns from 'node:dns';
 import https from 'node:https';
 import { SocksProxyAgent } from 'socks-proxy-agent';
-import { start } from './bot/start';
+import { start, isSunsetMode } from './bot/start';
 import { connect as mongoConnect } from './db_connect';
 import { resubscribeInvoices } from './ln';
 import { logger } from './logger';
@@ -12,6 +12,63 @@ import { imageCache } from './util/imageCache';
 import { createIndexes } from './models/indexes';
 import { CommunityContext } from './bot/modules/community/communityContext';
 import { startMonitoring } from './monitoring';
+
+const buildBotOptions = (): Partial<Telegraf.Options<CommunityContext>> => {
+  // Use configurable bot handler timeout, default to 60 seconds
+  const handlerTimeout = parseInt(process.env.BOT_HANDLER_TIMEOUT || '60000');
+  const socksProxyHost = process.env.SOCKS_PROXY_HOST?.trim();
+  const telegramAgent = socksProxyHost
+    ? (() => {
+        const proxyUrl = /^socks[45]?:\/\//i.test(socksProxyHost)
+          ? socksProxyHost
+          : `socks5://${socksProxyHost}`;
+        logger.info(`Using SOCKS proxy for Telegram API: ${proxyUrl}`);
+        return new SocksProxyAgent(proxyUrl) as any;
+      })()
+    : (() => {
+        logger.info('Using direct HTTPS agent for Telegram API (IPv4 forced)');
+        return new https.Agent({
+          family: 4,
+          keepAlive: true,
+          timeout: 60000,
+        }) as any;
+      })();
+
+  return {
+    handlerTimeout,
+    telegram: {
+      agent: telegramAgent,
+    },
+  };
+};
+
+// In sunset mode the bot only answers with a service-discontinued notice, so
+// it must be able to run even when MongoDB is gone
+const startSunsetBot = async (): Promise<void> => {
+  logger.notice(
+    'SUNSET_MODE is on: starting bot without database, LN node connection or monitoring.',
+  );
+  await start(String(process.env.BOT_TOKEN), buildBotOptions());
+};
+
+const startBot = async (): Promise<void> => {
+  logger.info('Connected to Mongo instance.');
+
+  // Create database indexes for optimized queries
+  await createIndexes();
+
+  // Initialize image cache for faster order creation
+  await imageCache.initialize();
+
+  const bot = await start(String(process.env.BOT_TOKEN), buildBotOptions());
+
+  // Wait 1 seconds before try to resubscribe hold invoices
+  await delay(1000);
+  await resubscribeInvoices(bot);
+
+  // Start external monitoring heartbeats (non-blocking, fails gracefully)
+  startMonitoring();
+};
 
 (async () => {
   dns.setDefaultResultOrder('ipv4first');
@@ -28,64 +85,21 @@ import { startMonitoring } from './monitoring';
     }
   });
 
+  if (isSunsetMode()) {
+    try {
+      await startSunsetBot();
+    } catch (error) {
+      logger.error(`Startup failed: ${error}`);
+      process.exit(1);
+    }
+    return;
+  }
+
   const mongoose = mongoConnect();
   mongoose.connection
     .once('open', async () => {
       try {
-        logger.info('Connected to Mongo instance.');
-
-        // Create database indexes for optimized queries
-        await createIndexes();
-
-        // Initialize image cache for faster order creation
-        await imageCache.initialize();
-
-        // Use configurable bot handler timeout, default to 60 seconds
-        const handlerTimeout = parseInt(
-          process.env.BOT_HANDLER_TIMEOUT || '60000',
-        );
-        let options: Partial<Telegraf.Options<CommunityContext>> = {
-          handlerTimeout,
-        };
-        const socksProxyHost = process.env.SOCKS_PROXY_HOST?.trim();
-        const telegramAgent = socksProxyHost
-          ? (() => {
-              const proxyUrl = /^socks[45]?:\/\//i.test(socksProxyHost)
-                ? socksProxyHost
-                : `socks5://${socksProxyHost}`;
-              logger.info(`Using SOCKS proxy for Telegram API: ${proxyUrl}`);
-              return new SocksProxyAgent(proxyUrl) as any;
-            })()
-          : (() => {
-              logger.info(
-                'Using direct HTTPS agent for Telegram API (IPv4 forced)',
-              );
-              return new https.Agent({
-                family: 4,
-                keepAlive: true,
-                timeout: 60000,
-              }) as any;
-            })();
-
-        options = {
-          ...options,
-          telegram: {
-            agent: telegramAgent,
-          },
-        };
-        const bot = await start(String(process.env.BOT_TOKEN), options);
-        if (process.env.SUNSET_MODE === 'true') {
-          logger.notice(
-            'SUNSET_MODE is on: skipping LN node connection and monitoring.',
-          );
-          return;
-        }
-        // Wait 1 seconds before try to resubscribe hold invoices
-        await delay(1000);
-        await resubscribeInvoices(bot);
-
-        // Start external monitoring heartbeats (non-blocking, fails gracefully)
-        startMonitoring();
+        await startBot();
       } catch (error) {
         logger.error(`Startup failed: ${error}`);
         process.exit(1);

--- a/bot/start.ts
+++ b/bot/start.ts
@@ -3,7 +3,7 @@ import { Telegraf, session, Context, Telegram } from 'telegraf';
 import { I18n, I18nContext } from '@grammyjs/i18n';
 import { Message } from 'typegram';
 import { UserDocument } from '../models/user';
-import { FilterQuery } from 'mongoose';
+import mongoose, { FilterQuery } from 'mongoose';
 import * as OrderEvents from './modules/events/orders';
 import { limit } from '@grammyjs/ratelimiter';
 import schedule from 'node-schedule';
@@ -175,14 +175,32 @@ const COMMIT_HASH = (() => {
   }
 })();
 
+// mongoose.ConnectionStates.connected, inlined because that enum is types-only
+const MONGO_CONNECTED_STATE = 1;
+
 const isSunsetMode = (): boolean => process.env.SUNSET_MODE === 'true';
+
+// Sunset mode can run without a database, so the stored language is a
+// best-effort lookup: it's skipped when Mongo is not connected and any query
+// failure falls back to the language reported by the Telegram client
+const findSunsetUser = async (tgId: string): Promise<UserDocument | null> => {
+  if (mongoose.connection.readyState !== MONGO_CONNECTED_STATE) {
+    return null;
+  }
+  try {
+    return await User.findOne({ tg_id: tgId });
+  } catch (error) {
+    logger.warning(`Could not read user language from database: ${error}`);
+    return null;
+  }
+};
 
 // When SUNSET_MODE is on the bot no longer trades: every incoming update is
 // answered with a service-discontinued notice in the user's language
 const sunsetMiddleware = async (ctx: MainContext): Promise<void> => {
   try {
     if (ctx.from === undefined) return;
-    const user = await User.findOne({ tg_id: ctx.from.id.toString() });
+    const user = await findSunsetUser(ctx.from.id.toString());
     const language = user?.lang || ctx.from.language_code || 'en';
     ctx.i18n.locale(language);
     await ctx.reply(ctx.i18n.t('sunset'), { disable_web_page_preview: true });
@@ -1221,4 +1239,4 @@ const start = async (
   return bot;
 };
 
-export { initialize, start, sunsetMiddleware };
+export { initialize, start, sunsetMiddleware, isSunsetMode };

--- a/db_connect.ts
+++ b/db_connect.ts
@@ -3,18 +3,25 @@ import { logger } from './logger';
 
 mongoose.set('strictQuery', false);
 
-// connect to database
-const credentials = process.env.DB_USER
-  ? `${process.env.DB_USER}:${process.env.DB_PASS}@`
-  : '';
-let MONGO_URI = `mongodb://${credentials}${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}?authSource=admin`;
-MONGO_URI = process.env.MONGO_URI ? process.env.MONGO_URI : MONGO_URI;
+const buildMongoUri = (): string => {
+  if (process.env.MONGO_URI) return process.env.MONGO_URI;
 
-if (!MONGO_URI) {
-  throw new Error('You must provide a MongoDB URI');
-}
-logger.info(`Connecting to MongoDB`);
+  if (!process.env.DB_HOST) {
+    throw new Error('You must provide a MongoDB URI');
+  }
+
+  const credentials = process.env.DB_USER
+    ? `${process.env.DB_USER}:${process.env.DB_PASS}@`
+    : '';
+
+  return `mongodb://${credentials}${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}?authSource=admin`;
+};
+
+// The connection settings are resolved lazily so that modes that don't need a
+// database (like sunset mode) can start without any DB_* / MONGO_URI variable
 const connect = () => {
+  const MONGO_URI = buildMongoUri();
+  logger.info(`Connecting to MongoDB`);
   mongoose.connect(MONGO_URI, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
@@ -22,4 +29,4 @@ const connect = () => {
   return mongoose;
 };
 
-export { connect };
+export { connect, buildMongoUri };

--- a/tests/bot/sunset.spec.ts
+++ b/tests/bot/sunset.spec.ts
@@ -1,7 +1,10 @@
 import path from 'path';
 import fs from 'fs';
 
-import { sunsetMiddleware } from '../../bot/start';
+import mongoose from 'mongoose';
+
+import { sunsetMiddleware, isSunsetMode } from '../../bot/start';
+import { buildMongoUri } from '../../db_connect';
 import { User } from '../../models';
 
 const sinon = require('sinon');
@@ -32,6 +35,8 @@ describe('sunset mode', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    // Pretend Mongo is connected unless a test says otherwise
+    sandbox.stub(mongoose.connection, 'readyState').value(1);
   });
 
   afterEach(() => {
@@ -68,6 +73,30 @@ describe('sunset mode', () => {
 
       expect(ctx.locales).to.deep.equal(['en']);
       expect(ctx.reply.calledOnce).to.equal(true);
+    });
+
+    it('replies using the Telegram language when the database is not connected', async () => {
+      sandbox.stub(mongoose.connection, 'readyState').value(0);
+      const findOne = sandbox.stub(User, 'findOne');
+      const ctx = makeCtx({ id: 1, language_code: 'it' });
+
+      await sunsetMiddleware(ctx as any);
+
+      expect(findOne.called).to.equal(false);
+      expect(ctx.locales).to.deep.equal(['it']);
+      expect(ctx.reply.calledOnce).to.equal(true);
+      expect(ctx.reply.firstCall.args[0]).to.equal('translated:sunset');
+    });
+
+    it('still replies when the user query fails', async () => {
+      sandbox.stub(User, 'findOne').rejects(new Error('no connection'));
+      const ctx = makeCtx({ id: 1, language_code: 'pt' });
+
+      await sunsetMiddleware(ctx as any);
+
+      expect(ctx.locales).to.deep.equal(['pt']);
+      expect(ctx.reply.calledOnce).to.equal(true);
+      expect(ctx.reply.firstCall.args[0]).to.equal('translated:sunset');
     });
 
     it('does not reply when the update has no sender', async () => {
@@ -115,6 +144,54 @@ describe('sunset mode', () => {
         expect(content).to.include('https://mostro.network');
         expect(content).to.include('https://mostro.community');
       });
+    });
+  });
+
+  describe('isSunsetMode', () => {
+    const original = process.env.SUNSET_MODE;
+
+    afterEach(() => {
+      if (original === undefined) delete process.env.SUNSET_MODE;
+      else process.env.SUNSET_MODE = original;
+    });
+
+    it('is enabled only when SUNSET_MODE is the string true', () => {
+      process.env.SUNSET_MODE = 'true';
+      expect(isSunsetMode()).to.equal(true);
+
+      process.env.SUNSET_MODE = 'false';
+      expect(isSunsetMode()).to.equal(false);
+
+      delete process.env.SUNSET_MODE;
+      expect(isSunsetMode()).to.equal(false);
+    });
+  });
+
+  describe('database configuration', () => {
+    const env = { ...process.env };
+
+    afterEach(() => {
+      process.env = { ...env };
+    });
+
+    it('does not require DB variables to be read at import time', () => {
+      delete process.env.MONGO_URI;
+      delete process.env.DB_HOST;
+
+      expect(() => buildMongoUri()).to.throw('You must provide a MongoDB URI');
+    });
+
+    it('builds the URI from DB_* variables', () => {
+      delete process.env.MONGO_URI;
+      process.env.DB_USER = 'user';
+      process.env.DB_PASS = 'pass';
+      process.env.DB_HOST = 'localhost';
+      process.env.DB_PORT = '27017';
+      process.env.DB_NAME = 'p2plnbot';
+
+      expect(buildMongoUri()).to.equal(
+        'mongodb://user:pass@localhost:27017/p2plnbot?authSource=admin',
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

In sunset mode the bot no longer trades: it only replies to every update with the service-discontinued notice pointing users to Mostro. Startup was still gated on the MongoDB `open` event, so once the database is decommissioned the bot could not start at all and users got no notice.

Now `SUNSET_MODE=true` starts the bot without touching MongoDB.

## Changes

- **`app.ts`**: when `SUNSET_MODE` is on, launch the bot directly — no Mongo connection, no index creation, no image cache, no LN resubscription, no monitoring. Telegram options building was extracted into `buildBotOptions()` so both paths share it.
- **`db_connect.ts`**: the connection URI is now resolved lazily inside `connect()` (and the "You must provide a MongoDB URI" check is real), so `DB_*` / `MONGO_URI` are only required when a connection is actually made.
- **`bot/start.ts`**: `sunsetMiddleware` looks up the stored user language only when Mongo is connected, and falls back to the Telegram client language on any query failure — so the notice is always delivered instead of buffering against a dead connection.
- **`.env-sample`**: documents that DB variables are optional in sunset mode.

## Test plan

- [x] `npm test` — 238 passing (5 new tests: no-DB language fallback, failing query fallback, `isSunsetMode`, lazy URI building)
- [x] `npm run lint` and Prettier clean
- [x] Manual smoke test: `env -i SUNSET_MODE=true BOT_TOKEN=... node ./dist/app` with no DB variables at all — bot starts, no Mongo connection attempted
- [ ] Verify on staging with the database stopped that incoming messages get the sunset notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBuhef1wR1Ers3D7oFrjWt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sunset mode now starts without connecting to MongoDB, the Lightning node, or monitoring services.
  - Sunset-mode responses can use a user’s Telegram language when account data is unavailable.
  - MongoDB connections can use `MONGO_URI` directly, with fallback support for individual database settings.

- **Documentation**
  - Updated sample configuration to clarify that database settings are optional when sunset mode is enabled.

- **Bug Fixes**
  - Improved startup reliability when the database is disconnected or user lookups fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->